### PR TITLE
Internal collector telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Next, select `otelcol-collector-0` from the `Pod` dropdown, to view the power co
 
 ### 6- Deploy kube-green
 
-Install kube-green
+Install kube-green. Keep in mind that since we're managing our Collector via the OTel Operator, Kube-Green will NOT sleep any Collector pods; it will only sleep application pods.
 
 ```bash
 ./src/scripts/06-install-kube-green.sh
@@ -271,6 +271,8 @@ Apply the sleep info
 ```bash
 kubectl apply -f src/k8s/10-sleep-info.yaml
 ```
+
+> **NOTE:** You'll need to update the sleep start/end times, and time zone, as it applies to your own.
 
 ## Useful Commands
 

--- a/src/k8s/01-target-allocator-rbac.yaml
+++ b/src/k8s/01-target-allocator-rbac.yaml
@@ -14,6 +14,8 @@ rules:
   resources:
   - servicemonitors
   - podmonitors
+  - scrapeconfigs
+  - probes
   verbs:
   - '*'
 - apiGroups: [""]

--- a/src/k8s/02-otel-collector-dt-app.yaml
+++ b/src/k8s/02-otel-collector-dt-app.yaml
@@ -42,6 +42,14 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
+    - name: K8S_POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: K8S_POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
     # This ain't pretty, but it will do for now
     - name: CLUSTERNAME
       value: "gke-kepler"
@@ -57,7 +65,10 @@ spec:
       # Required for Dynatrace metrics processing
       # Ref: https://docs.dynatrace.com/docs/ingest-from/opentelemetry/collector/configuration#delta-metrics
       cumulativetodelta: {}
-      batch: {}
+      batch:
+        send_batch_max_size: 1000
+        timeout: 30s
+        send_batch_size : 800
 
       # Prevent out of memory (OOM) situations on the Collector
       memory_limiter:
@@ -195,18 +206,45 @@ spec:
           exporters: [ otlphttp/dt, debug ]
 
       telemetry:
-          metrics:
-            level: detailed
-            readers:
-              - periodic:
-                  interval: 1000
-                  exporter:
-                    otlp:
-                      protocol: http/protobuf
-                      temporality_preference: delta
-                      # endpoint: http://otelcol-collector.opentelemetry.svc.cluster.local:4318
-                      # Workaround to get temporality_preference config to get picked up: https://github.com/open-telemetry/opentelemetry-collector/issues/13080
-                      endpoint: https://${DT_ENV}/api/v2/otlp/v1/metrics
-                      headers:
-                        - name: Authorization
-                          value: "Api-Token ${DT_TOKEN}"
+        resource:
+          k8s.namespace.name: "${env:K8S_POD_NAMESPACE}"
+          k8s.pod.name: "${env:K8S_POD_NAME}"
+          k8s.node.name: "${env:K8S_NODE_NAME}"
+
+        metrics:
+          level: detailed
+          readers:
+            - periodic:
+                # interval: 1000
+                exporter:
+                  otlp:
+                    protocol: http/protobuf
+                    temporality_preference: delta
+                    # endpoint: http://otelcol-collector.opentelemetry.svc.cluster.local:4318
+                    # Workaround to get temporality_preference config to get picked up: https://github.com/open-telemetry/opentelemetry-collector/issues/13080
+                    endpoint: https://${DT_ENV}/api/v2/otlp/v1/metrics
+                    headers:
+                      - name: Authorization
+                        value: "Api-Token ${DT_TOKEN}"
+        logs:
+          level: debug
+          output_paths: ["stdout"]
+          processors:
+            - batch:
+                exporter:
+                  otlp:
+                    protocol: http/protobuf
+                    endpoint: https://${DT_ENV}/api/v2/otlp/v1/logs
+                    headers:
+                      - name: Authorization
+                        value: "Api-Token ${DT_TOKEN}"
+        traces:
+          processors:
+            - batch:
+                exporter:
+                  otlp:
+                    protocol: http/protobuf
+                    endpoint: https://${DT_ENV}/api/v2/otlp/v1/traces
+                    headers:
+                      - name: Authorization
+                        value: "Api-Token ${DT_TOKEN}"

--- a/src/k8s/02-otel-collector-dt-k8s.yaml
+++ b/src/k8s/02-otel-collector-dt-k8s.yaml
@@ -47,6 +47,14 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
+    - name: K8S_POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: K8S_POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
     # This ain't pretty, but it will do for now
     - name: CLUSTERNAME
       value: "gke-kepler"
@@ -94,7 +102,10 @@ spec:
       # Required for Dynatrace metrics processing
       # Ref: https://docs.dynatrace.com/docs/ingest-from/opentelemetry/collector/configuration#delta-metrics
       cumulativetodelta: {}
-      batch: {}
+      batch:
+        send_batch_max_size: 1000
+        timeout: 30s
+        send_batch_size : 800
 
       # Prevent out of memory (OOM) situations on the Collector
       memory_limiter:
@@ -178,18 +189,45 @@ spec:
           exporters: [ otlphttp/dt, debug ]
 
       telemetry:
-          metrics:
-            level: detailed
-            readers:
-              - periodic:
-                  interval: 1000
-                  exporter:
-                    otlp:
-                      protocol: http/protobuf
-                      temporality_preference: delta
-                      # endpoint: http://otelcol-collector.opentelemetry.svc.cluster.local:4318
-                      # Workaround to get temporality_preference config to get picked up: https://github.com/open-telemetry/opentelemetry-collector/issues/13080
-                      endpoint: https://${DT_ENV}/api/v2/otlp/v1/metrics
-                      headers:
-                        - name: Authorization
-                          value: "Api-Token ${DT_TOKEN}"
+        resource:
+          k8s.namespace.name: "${env:K8S_POD_NAMESPACE}"
+          k8s.pod.name: "${env:K8S_POD_NAME}"
+          k8s.node.name: "${env:K8S_NODE_NAME}"
+
+        metrics:
+          level: detailed
+          readers:
+            - periodic:
+                # interval: 1000
+                exporter:
+                  otlp:
+                    protocol: http/protobuf
+                    temporality_preference: delta
+                    # endpoint: http://otelcol-collector.opentelemetry.svc.cluster.local:4318
+                    # Workaround to get temporality_preference config to get picked up: https://github.com/open-telemetry/opentelemetry-collector/issues/13080
+                    endpoint: https://${DT_ENV}/api/v2/otlp/v1/metrics
+                    headers:
+                      - name: Authorization
+                        value: "Api-Token ${DT_TOKEN}"
+        logs:
+          level: debug
+          output_paths: ["stdout"]
+          processors:
+            - batch:
+                exporter:
+                  otlp:
+                    protocol: http/protobuf
+                    endpoint: https://${DT_ENV}/api/v2/otlp/v1/logs
+                    headers:
+                      - name: Authorization
+                        value: "Api-Token ${DT_TOKEN}"
+        traces:
+          processors:
+            - batch:
+                exporter:
+                  otlp:
+                    protocol: http/protobuf
+                    endpoint: https://${DT_ENV}/api/v2/otlp/v1/traces
+                    headers:
+                      - name: Authorization
+                        value: "Api-Token ${DT_TOKEN}"

--- a/src/k8s/02-otel-collector-dt-ocb.yaml
+++ b/src/k8s/02-otel-collector-dt-ocb.yaml
@@ -48,6 +48,14 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
+    - name: K8S_POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: K8S_POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
     # This ain't pretty, but it will do for now
     - name: CLUSTERNAME
       value: "gke-kepler"
@@ -99,7 +107,11 @@ spec:
       # Required for Dynatrace metrics processing
       # Ref: https://docs.dynatrace.com/docs/ingest-from/opentelemetry/collector/configuration#delta-metrics
       cumulativetodelta: {}
-      batch: {}
+      batch:
+        send_batch_max_size: 1000
+        timeout: 30s
+        send_batch_size : 800
+
 
       # Prevent out of memory (OOM) situations on the Collector
       memory_limiter:
@@ -260,18 +272,45 @@ spec:
           exporters: [ otlphttp/dt, debug ]
 
       telemetry:
-          metrics:
-            level: detailed
-            readers:
-              - periodic:
-                  interval: 1000
-                  exporter:
-                    otlp:
-                      protocol: http/protobuf
-                      temporality_preference: delta
-                      # endpoint: http://otelcol-collector.opentelemetry.svc.cluster.local:4318
-                      # Workaround to get temporality_preference config to get picked up: https://github.com/open-telemetry/opentelemetry-collector/issues/13080
-                      endpoint: https://${DT_ENV}/api/v2/otlp/v1/metrics
-                      headers:
-                        - name: Authorization
-                          value: "Api-Token ${DT_TOKEN}"
+        resource:
+          k8s.namespace.name: "${env:K8S_POD_NAMESPACE}"
+          k8s.pod.name: "${env:K8S_POD_NAME}"
+          k8s.node.name: "${env:K8S_NODE_NAME}"
+
+        metrics:
+          level: detailed
+          readers:
+            - periodic:
+                # interval: 1000
+                exporter:
+                  otlp:
+                    protocol: http/protobuf
+                    temporality_preference: delta
+                    # endpoint: http://otelcol-collector.opentelemetry.svc.cluster.local:4318
+                    # Workaround to get temporality_preference config to get picked up: https://github.com/open-telemetry/opentelemetry-collector/issues/13080
+                    endpoint: https://${DT_ENV}/api/v2/otlp/v1/metrics
+                    headers:
+                      - name: Authorization
+                        value: "Api-Token ${DT_TOKEN}"
+        logs:
+          level: debug
+          output_paths: ["stdout"]
+          processors:
+            - batch:
+                exporter:
+                  otlp:
+                    protocol: http/protobuf
+                    endpoint: https://${DT_ENV}/api/v2/otlp/v1/logs
+                    headers:
+                      - name: Authorization
+                        value: "Api-Token ${DT_TOKEN}"
+        traces:
+          processors:
+            - batch:
+                exporter:
+                  otlp:
+                    protocol: http/protobuf
+                    endpoint: https://${DT_ENV}/api/v2/otlp/v1/traces
+                    headers:
+                      - name: Authorization
+                        value: "Api-Token ${DT_TOKEN}"

--- a/src/k8s/02-otel-collector-dt.yaml
+++ b/src/k8s/02-otel-collector-dt.yaml
@@ -47,6 +47,14 @@ spec:
       valueFrom:
         fieldRef:
           fieldPath: spec.nodeName
+    - name: K8S_POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: K8S_POD_NAMESPACE
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.namespace
     # This ain't pretty, but it will do for now
     - name: CLUSTERNAME
       value: "gke-kepler"
@@ -98,7 +106,10 @@ spec:
       # Required for Dynatrace metrics processing
       # Ref: https://docs.dynatrace.com/docs/ingest-from/opentelemetry/collector/configuration#delta-metrics
       cumulativetodelta: {}
-      batch: {}
+      batch:
+        send_batch_max_size: 1000
+        timeout: 30s
+        send_batch_size : 800
 
       # Prevent out of memory (OOM) situations on the Collector
       memory_limiter:
@@ -259,18 +270,45 @@ spec:
           exporters: [ otlphttp/dt, debug ]
 
       telemetry:
-          metrics:
-            level: detailed
-            readers:
-              - periodic:
-                  interval: 1000
-                  exporter:
-                    otlp:
-                      protocol: http/protobuf
-                      temporality_preference: delta
-                      # endpoint: http://otelcol-collector.opentelemetry.svc.cluster.local:4318
-                      # Workaround to get temporality_preference config to get picked up: https://github.com/open-telemetry/opentelemetry-collector/issues/13080
-                      endpoint: https://${DT_ENV}/api/v2/otlp/v1/metrics
-                      headers:
-                        - name: Authorization
-                          value: "Api-Token ${DT_TOKEN}"
+        resource:
+          k8s.namespace.name: "${env:K8S_POD_NAMESPACE}"
+          k8s.pod.name: "${env:K8S_POD_NAME}"
+          k8s.node.name: "${env:K8S_NODE_NAME}"
+
+        metrics:
+          level: detailed
+          readers:
+            - periodic:
+                # interval: 1000
+                exporter:
+                  otlp:
+                    protocol: http/protobuf
+                    temporality_preference: delta
+                    # endpoint: http://otelcol-collector.opentelemetry.svc.cluster.local:4318
+                    # Workaround to get temporality_preference config to get picked up: https://github.com/open-telemetry/opentelemetry-collector/issues/13080
+                    endpoint: https://${DT_ENV}/api/v2/otlp/v1/metrics
+                    headers:
+                      - name: Authorization
+                        value: "Api-Token ${DT_TOKEN}"
+        logs:
+          level: info
+          output_paths: ["stdout"]
+          processors:
+            - batch:
+                exporter:
+                  otlp:
+                    protocol: http/protobuf
+                    endpoint: https://${DT_ENV}/api/v2/otlp/v1/logs
+                    headers:
+                      - name: Authorization
+                        value: "Api-Token ${DT_TOKEN}"
+        traces:
+          processors:
+            - batch:
+                exporter:
+                  otlp:
+                    protocol: http/protobuf
+                    endpoint: https://${DT_ENV}/api/v2/otlp/v1/traces
+                    headers:
+                      - name: Authorization
+                        value: "Api-Token ${DT_TOKEN}"

--- a/src/kepler/otel_collector_single_collector.json
+++ b/src/kepler/otel_collector_single_collector.json
@@ -1,0 +1,2976 @@
+{
+    "version": 18,
+    "variables": [
+        {
+            "key": "CollectorServiceNames",
+            "visible": true,
+            "type": "csv",
+            "version": 1,
+            "editable": true,
+            "input": "dynatrace-otel-collector,otelcorecol,otelcontribcol,otelcol,otelcol-contrib,otelcol-dev",
+            "multiple": true,
+            "defaultValue": [
+                "dynatrace-otel-collector",
+                "otelcorecol",
+                "otelcontribcol",
+                "otelcol",
+                "otelcol-contrib"
+            ]
+        },
+        {
+            "version": 1,
+            "key": "K8sPodName",
+            "type": "query",
+            "visible": true,
+            "editable": true,
+            "input": "fetch logs\n| filter matchesPhrase(k8s.pod.name, \"otelcol-collector\")\n| summarize count = count(), by: { k8s.pod.name }\n| fields k8s.pod.name",
+            "multiple": false,
+            "defaultValue": "-"
+        }
+    ],
+    "tiles": {
+        "11": {
+            "type": "markdown",
+            "content": "### Memory and CPU time"
+        },
+        "39": {
+            "title": "Request count",
+            "description": "This tile shows a timeseries of the incoming HTTP request count of  the OpenTelemetry Collector.",
+            "type": "data",
+            "query": "// This query retrieves a timeseries of the incoming HTTP request count of  the OpenTelemetry Collector.\ntimeseries { sum(http.server.duration, rollup:count) },\n  by: { http.status_code },\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }",
+            "visualization": "lineChart",
+            "visualizationSettings": {
+                "thresholds": [],
+                "chartSettings": {
+                    "xAxisScaling": "analyzedTimeframe",
+                    "gapPolicy": "gap",
+                    "circleChartSettings": {
+                        "groupingThresholdType": "relative",
+                        "groupingThresholdValue": 0,
+                        "valueType": "relative"
+                    },
+                    "categoryOverrides": {},
+                    "categoricalBarChartSettings": {
+                        "categoryAxisLabel": "http.status_code",
+                        "valueAxisLabel": "interval",
+                        "categoryAxis": "http.status_code",
+                        "valueAxis": [
+                            "interval"
+                        ],
+                        "tooltipVariant": "single"
+                    },
+                    "fieldMapping": {
+                        "timestamp": "timeframe",
+                        "leftAxisValues": [
+                            "sum(http.server.duration, rollup:total)"
+                        ],
+                        "leftAxisDimensions": [
+                            "http.status_code"
+                        ]
+                    },
+                    "hiddenLegendFields": [],
+                    "truncationMode": "middle",
+                    "xAxisLabel": "timeframe",
+                    "xAxisIsLabelVisible": false,
+                    "valueRepresentation": "absolute",
+                    "leftYAxisSettings": {}
+                },
+                "singleValue": {
+                    "showLabel": true,
+                    "label": "",
+                    "prefixIcon": "",
+                    "recordField": "service.name",
+                    "autoscale": true,
+                    "alignment": "center",
+                    "colorThresholdTarget": "value"
+                },
+                "table": {
+                    "rowDensity": "condensed",
+                    "enableSparklines": false,
+                    "hiddenColumns": [],
+                    "lineWrapIds": [],
+                    "columnWidths": {},
+                    "columnTypeOverrides": [
+                        {
+                            "fields": [
+                                "sum(http.server.duration, rollup:total)"
+                            ],
+                            "value": "sparkline",
+                            "id": 1744115263708
+                        }
+                    ]
+                },
+                "honeycomb": {
+                    "shape": "hexagon",
+                    "legend": "auto",
+                    "dataMappings": {
+                        "value": "interval"
+                    },
+                    "displayedFields": [
+                        "http.status_code"
+                    ],
+                    "colorMode": "color-palette",
+                    "colorPalette": "blue"
+                },
+                "histogram": {
+                    "dataMappings": [
+                        {
+                            "valueAxis": "interval",
+                            "rangeAxis": ""
+                        }
+                    ]
+                },
+                "valueBoundaries": {
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "unitsOverrides": []
+            },
+            "querySettings": {
+                "maxResultRecords": 1000,
+                "defaultScanLimitGbytes": 500,
+                "maxResultMegaBytes": 1,
+                "defaultSamplingRatio": 10,
+                "enableSampling": false
+            },
+            "davis": {}
+        },
+        "42": {
+            "type": "markdown",
+            "content": "### Telemetry data passing through the collector"
+        },
+        "44": {
+            "title": "Span totals",
+            "description": "This tile shows how many spans have been accepted/refused by the receivers, and how many have been sent/failed by the exporters of the selected OpenTelemetry Collector instance. ",
+            "type": "data",
+            "query": "// This query retrieves how many spans have been accepted/refused by the receivers, and how many have been sent/failed by the exporters of the selected OpenTelemetry Collector instance. \ntimeseries { accepted=sum(otelcol_receiver_accepted_spans) },\n  by: {receiver},\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }\n  | fieldsAdd name=\"accepted\", type=\"receiver\", component=receiver, value=arraySum(accepted)\n  | fieldsKeep name, type, component, value\n| append [\n  timeseries { refused=sum(otelcol_receiver_refused_spans) }, \n  by: {receiver},\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }  \n  | fieldsAdd name=\"refused\", type=\"receiver\", component=receiver, value=arraySum(refused)\n  | fieldsKeep name, type, component, value\n] | append [\n  timeseries { filtered=sum(otelcol_processor_filter_spans.filtered) },\n  by: {filter},\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }    \n  | fieldsAdd name=\"filtered\", type=\"processor\", component=filter, value=arraySum(filtered)\n  | fieldsKeep name, type, component, value\n]\n| append [\n  timeseries {sent=sum(otelcol_exporter_sent_spans)}, \n  by: { exporter },\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }  \n  | fieldsAdd name=\"sent\", type=\"exporter\", component=exporter, value=arraySum(sent)\n  | fieldsKeep name, type, component, value\n]\n| append [\n  timeseries {failed=sum(otelcol_exporter_send_failed_spans) }, \n  by: { exporter },\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }  \n  | fieldsAdd name=\"failed\", type=\"exporter\", component=exporter, value=arraySum(failed)\n  | fieldsKeep name, type, component, value\n]\n| fields name, type, component, value=toLong(value)",
+            "visualization": "table",
+            "visualizationSettings": {
+                "thresholds": [],
+                "chartSettings": {
+                    "xAxisScaling": "analyzedTimeframe",
+                    "gapPolicy": "connect",
+                    "circleChartSettings": {
+                        "groupingThresholdType": "relative",
+                        "groupingThresholdValue": 0,
+                        "valueType": "relative"
+                    },
+                    "categoryOverrides": {},
+                    "hiddenLegendFields": [],
+                    "categoricalBarChartSettings": {
+                        "categoryAxis": "name",
+                        "valueAxis": [
+                            "value"
+                        ],
+                        "categoryAxisLabel": "name",
+                        "valueAxisLabel": "value",
+                        "tooltipVariant": "single"
+                    },
+                    "truncationMode": "middle"
+                },
+                "singleValue": {
+                    "showLabel": true,
+                    "label": "",
+                    "prefixIcon": "",
+                    "autoscale": true,
+                    "alignment": "center",
+                    "colorThresholdTarget": "value",
+                    "recordField": "receiver"
+                },
+                "table": {
+                    "rowDensity": "condensed",
+                    "enableSparklines": false,
+                    "hiddenColumns": [],
+                    "lineWrapIds": [],
+                    "columnWidths": {
+                        "[\"name\"]": 111.89999389648438
+                    },
+                    "columnTypeOverrides": []
+                },
+                "honeycomb": {
+                    "shape": "hexagon",
+                    "legend": {
+                        "0": "a",
+                        "1": "u",
+                        "2": "t",
+                        "3": "o",
+                        "hidden": true
+                    },
+                    "dataMappings": {
+                        "value": "value"
+                    },
+                    "displayedFields": [
+                        "name",
+                        "type",
+                        "component"
+                    ],
+                    "colorMode": "color-palette",
+                    "colorPalette": "blue"
+                },
+                "histogram": {
+                    "dataMappings": [
+                        {
+                            "valueAxis": "value",
+                            "rangeAxis": ""
+                        }
+                    ]
+                },
+                "valueBoundaries": {
+                    "min": "auto",
+                    "max": "auto"
+                }
+            },
+            "querySettings": {
+                "maxResultRecords": 1000,
+                "defaultScanLimitGbytes": 500,
+                "maxResultMegaBytes": 1,
+                "defaultSamplingRatio": 10,
+                "enableSampling": false
+            },
+            "davis": {}
+        },
+        "75": {
+            "title": "Span totals",
+            "description": "This tile shows a timeseries of all spans that have passed through the selected OpenTelemetry Collector instance.",
+            "type": "data",
+            "query": "// This query retrieves a timeseries of all spans that have passed through the selected OpenTelemetry Collector instance.\ntimeseries {accepted=sum(otelcol_receiver_accepted_spans)}, \nfilter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName },\nby: {receiver}\n| fieldsAdd type=\"receiver\"\n| append [\n  timeseries {refused=sum(otelcol_receiver_refused_spans)}, \n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName },\n  by: {receiver}\n  | fieldsAdd type=\"receiver\"\n] | append [\n  timeseries {filtered=sum(otelcol_processor_filter_spans.filtered)},\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName },\n  by: {filter}\n  | fieldsAdd type=\"processor\"\n] | append [\n  timeseries {sent=sum(otelcol_exporter_sent_spans)}, \n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName },\n  by: {exporter}\n  | fieldsAdd type=\"exporter\"\n] | append [\n  timeseries {failed=sum(otelcol_exporter_send_failed_spans)}, \n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName },\n  by: { exporter }\n  | fieldsAdd type=\"exporter\"\n]\n  // todo name for filter column\n| fields timeframe, interval, type, accepted, refused, sent, failed, filtered, receiver, exporter",
+            "visualization": "lineChart",
+            "visualizationSettings": {
+                "thresholds": [],
+                "chartSettings": {
+                    "gapPolicy": "connect",
+                    "circleChartSettings": {
+                        "groupingThresholdType": "relative",
+                        "groupingThresholdValue": 0,
+                        "valueType": "relative"
+                    },
+                    "categoryOverrides": {},
+                    "categoricalBarChartSettings": {
+                        "categoryAxisLabel": "type",
+                        "valueAxisLabel": "interval",
+                        "tooltipVariant": "single"
+                    },
+                    "hiddenLegendFields": [],
+                    "fieldMapping": {
+                        "timestamp": "timeframe",
+                        "leftAxisValues": [
+                            "accepted",
+                            "refused",
+                            "sent",
+                            "failed"
+                        ]
+                    },
+                    "truncationMode": "middle",
+                    "bandChartSettings": {
+                        "lower": "accepted",
+                        "upper": "refused"
+                    },
+                    "xAxisScaling": "analyzedTimeframe",
+                    "xAxisLabel": "timeframe",
+                    "xAxisIsLabelVisible": false,
+                    "valueRepresentation": "absolute",
+                    "leftYAxisSettings": {
+                        "isLabelVisible": true,
+                        "label": "otelcol_receiver_accepted_spans • otelcol_receiver_refused_spans • otelcol_exporter_sent_spans • otelcol_exporter_send_failed_spans"
+                    }
+                },
+                "singleValue": {
+                    "showLabel": true,
+                    "label": "",
+                    "prefixIcon": "",
+                    "recordField": "service.name",
+                    "autoscale": true,
+                    "alignment": "center",
+                    "colorThresholdTarget": "value"
+                },
+                "table": {
+                    "rowDensity": "condensed",
+                    "enableSparklines": false,
+                    "hiddenColumns": [],
+                    "lineWrapIds": [],
+                    "columnWidths": {},
+                    "columnTypeOverrides": [
+                        {
+                            "fields": [
+                                "failed"
+                            ],
+                            "value": "sparkline",
+                            "id": 1744115216958
+                        }
+                    ]
+                },
+                "honeycomb": {
+                    "shape": "hexagon",
+                    "legend": "auto",
+                    "dataMappings": {
+                        "value": "interval"
+                    },
+                    "displayedFields": [
+                        "type"
+                    ],
+                    "colorMode": "color-palette",
+                    "colorPalette": "blue"
+                },
+                "histogram": {
+                    "dataMappings": [
+                        {
+                            "valueAxis": "interval",
+                            "rangeAxis": ""
+                        }
+                    ]
+                },
+                "valueBoundaries": {
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "unitsOverrides": []
+            },
+            "querySettings": {
+                "maxResultRecords": 1000,
+                "defaultScanLimitGbytes": 500,
+                "maxResultMegaBytes": 1,
+                "defaultSamplingRatio": 10,
+                "enableSampling": false
+            },
+            "davis": {
+                "enabled": false,
+                "davisVisualization": {
+                    "isAvailable": true
+                }
+            }
+        },
+        "76": {
+            "title": "Metric datapoint totals",
+            "description": "This tile shows a timeseries of all metric datapoints that have passed through the selected OpenTelemetry Collector instance.",
+            "type": "data",
+            "query": "// This query retrieves a timeseries of all metric datapoints that have passed through the selected OpenTelemetry Collector instance.\ntimeseries {accepted=sum(otelcol_receiver_accepted_metric_points)},\nfilter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName },\nby: {receiver}\n| fieldsAdd type=\"receiver\"\n| append [\n  timeseries {refused=sum(otelcol_receiver_refused_metric_points)}, \n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName },\n  by: {receiver}\n| fieldsAdd type=\"receiver\"\n] | append [\n  timeseries {filtered=sum(otelcol_processor_filter_datapoints.filtered)},\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName },\n  by: {filter}\n  | fieldsAdd type=\"processor\"\n] | append [\n  timeseries {sent=sum(otelcol_exporter_sent_metric_points)}, \n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName },\n  by: {exporter}\n  | fieldsAdd type=\"exporter\"\n] | append [\n  timeseries {failed=sum(otelcol_exporter_send_failed_metric_points)}, \n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName },\n  by: {exporter}\n  | fieldsAdd type=\"exporter\"\n] \n| fields timeframe, interval, type, accepted, refused, sent, failed, filtered, receiver, exporter",
+            "visualization": "lineChart",
+            "visualizationSettings": {
+                "thresholds": [],
+                "chartSettings": {
+                    "xAxisScaling": "analyzedTimeframe",
+                    "gapPolicy": "connect",
+                    "circleChartSettings": {
+                        "groupingThresholdType": "relative",
+                        "groupingThresholdValue": 0,
+                        "valueType": "relative"
+                    },
+                    "categoryOverrides": {},
+                    "categoricalBarChartSettings": {
+                        "categoryAxisLabel": "type",
+                        "valueAxisLabel": "interval",
+                        "tooltipVariant": "single"
+                    },
+                    "hiddenLegendFields": [],
+                    "fieldMapping": {
+                        "timestamp": "timeframe",
+                        "leftAxisValues": [
+                            "accepted",
+                            "refused",
+                            "sent",
+                            "failed"
+                        ]
+                    },
+                    "truncationMode": "middle",
+                    "bandChartSettings": {
+                        "lower": "accepted",
+                        "upper": "refused"
+                    },
+                    "xAxisLabel": "timeframe",
+                    "xAxisIsLabelVisible": false,
+                    "valueRepresentation": "absolute",
+                    "leftYAxisSettings": {
+                        "isLabelVisible": true,
+                        "label": "otelcol_receiver_accepted_metric_points • otelcol_receiver_refused_metric_points • otelcol_exporter_sent_metric_points • otelcol_exporter_send_failed_metric_points"
+                    }
+                },
+                "singleValue": {
+                    "showLabel": true,
+                    "label": "",
+                    "prefixIcon": "",
+                    "recordField": "service.name",
+                    "autoscale": true,
+                    "alignment": "center",
+                    "colorThresholdTarget": "value"
+                },
+                "table": {
+                    "rowDensity": "condensed",
+                    "enableSparklines": false,
+                    "hiddenColumns": [],
+                    "lineWrapIds": [],
+                    "columnWidths": {},
+                    "columnTypeOverrides": [
+                        {
+                            "fields": [
+                                "failed"
+                            ],
+                            "value": "sparkline",
+                            "id": 1744115216903
+                        }
+                    ]
+                },
+                "honeycomb": {
+                    "shape": "hexagon",
+                    "legend": "auto",
+                    "dataMappings": {
+                        "value": "interval"
+                    },
+                    "displayedFields": [
+                        "type"
+                    ],
+                    "colorMode": "color-palette",
+                    "colorPalette": "blue"
+                },
+                "histogram": {
+                    "dataMappings": [
+                        {
+                            "valueAxis": "interval",
+                            "rangeAxis": ""
+                        }
+                    ]
+                },
+                "valueBoundaries": {
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "unitsOverrides": []
+            },
+            "querySettings": {
+                "maxResultRecords": 1000,
+                "defaultScanLimitGbytes": 500,
+                "maxResultMegaBytes": 1,
+                "defaultSamplingRatio": 10,
+                "enableSampling": false
+            },
+            "davis": {
+                "enabled": false,
+                "davisVisualization": {
+                    "isAvailable": true
+                }
+            }
+        },
+        "77": {
+            "title": "Log totals",
+            "description": "This tile shows a timeseries of all logs that have passed through the selected OpenTelemetry Collector instance.",
+            "type": "data",
+            "query": "// This query retrieves a timeseries of all logs that have passed through the selected OpenTelemetry Collector instance.\ntimeseries {accepted=sum(otelcol_receiver_accepted_log_records)}, \nfilter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName },\nby: {receiver}\n| fieldsAdd type=\"receiver\"\n| append [\n  timeseries {refused=sum(otelcol_receiver_refused_log_records)}, \nfilter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName },\nby: {receiver}\n| fieldsAdd type=\"receiver\"\n] | append [\n  timeseries {filtered=sum(otelcol_processor_filter_logs.filtered)},\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName },\n  by: {filter}\n  | fieldsAdd type=\"processor\"\n] | append [\n  timeseries {sent=sum(otelcol_exporter_sent_log_records)}, \n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName },\n  by: {exporter}\n  | fieldsAdd type=\"exporter\"\n] | append [\n  timeseries {failed=sum(otelcol_exporter_send_failed_log_records)}, \n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName },\n  by: {exporter}\n  | fieldsAdd type=\"exporter\"\n]\n| fields timeframe, interval, type, accepted, refused, sent, failed, filtered, receiver, exporter",
+            "visualization": "lineChart",
+            "visualizationSettings": {
+                "thresholds": [],
+                "chartSettings": {
+                    "xAxisScaling": "analyzedTimeframe",
+                    "gapPolicy": "connect",
+                    "circleChartSettings": {
+                        "groupingThresholdType": "relative",
+                        "groupingThresholdValue": 0,
+                        "valueType": "relative"
+                    },
+                    "categoryOverrides": {},
+                    "categoricalBarChartSettings": {
+                        "categoryAxisLabel": "type",
+                        "valueAxisLabel": "interval",
+                        "categoryAxis": "type",
+                        "valueAxis": [
+                            "interval"
+                        ],
+                        "tooltipVariant": "single"
+                    },
+                    "hiddenLegendFields": [],
+                    "fieldMapping": {
+                        "timestamp": "timeframe",
+                        "leftAxisValues": [
+                            "accepted",
+                            "refused",
+                            "sent",
+                            "failed"
+                        ],
+                        "leftAxisDimensions": [
+                            "type",
+                            "receiver",
+                            "exporter"
+                        ]
+                    },
+                    "truncationMode": "middle",
+                    "bandChartSettings": {
+                        "lower": "accepted",
+                        "upper": "refused"
+                    },
+                    "xAxisLabel": "timeframe",
+                    "xAxisIsLabelVisible": false,
+                    "valueRepresentation": "absolute",
+                    "leftYAxisSettings": {}
+                },
+                "singleValue": {
+                    "showLabel": true,
+                    "label": "",
+                    "prefixIcon": "",
+                    "recordField": "service.name",
+                    "autoscale": true,
+                    "alignment": "center",
+                    "colorThresholdTarget": "value"
+                },
+                "table": {
+                    "rowDensity": "condensed",
+                    "enableSparklines": false,
+                    "hiddenColumns": [],
+                    "lineWrapIds": [],
+                    "columnWidths": {},
+                    "columnTypeOverrides": [
+                        {
+                            "fields": [
+                                "accepted",
+                                "refused",
+                                "sent",
+                                "failed"
+                            ],
+                            "value": "sparkline",
+                            "id": 1744115217032
+                        }
+                    ]
+                },
+                "honeycomb": {
+                    "shape": "hexagon",
+                    "legend": "auto",
+                    "dataMappings": {
+                        "value": "interval"
+                    },
+                    "displayedFields": [
+                        "type"
+                    ],
+                    "colorMode": "color-palette",
+                    "colorPalette": "blue"
+                },
+                "histogram": {
+                    "dataMappings": [
+                        {
+                            "valueAxis": "interval",
+                            "rangeAxis": ""
+                        }
+                    ]
+                },
+                "valueBoundaries": {
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "unitsOverrides": []
+            },
+            "querySettings": {
+                "maxResultRecords": 1000,
+                "defaultScanLimitGbytes": 500,
+                "maxResultMegaBytes": 1,
+                "defaultSamplingRatio": 10,
+                "enableSampling": false
+            },
+            "davis": {
+                "enabled": false,
+                "davisVisualization": {
+                    "isAvailable": true
+                }
+            }
+        },
+        "79": {
+            "title": "Metric datapoint totals",
+            "description": "This tile shows how many metric datapoints have been accepted/refused by the receivers, and how many have been sent/failed by the exporters of the selected OpenTelemetry Collector instance. ",
+            "type": "data",
+            "query": "// This query retrieves how many metric datapoints have been accepted/refused by the receivers, and how many have been sent/failed by the exporters of the selected OpenTelemetry Collector instance. \ntimeseries { accepted=sum(otelcol_receiver_accepted_metric_points) }, \n  by: { receiver },\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }\n  | fieldsAdd name=\"accepted\", type=\"receiver\", component=receiver, value=arraySum(accepted)\n  | fieldsKeep name, type, component, value\n| append [\n  timeseries { refused=sum(otelcol_receiver_refused_metric_points) }, \n  by: { receiver },\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }\n  | fieldsAdd name=\"refused\", type=\"receiver\", component=receiver, value=arraySum(refused)\n  | fieldsKeep name, type, component, value\n]\n| append [\n  timeseries { filtered=sum(otelcol_processor_filter_datapoints.filtered) }, \n  by: {filter},\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }    \n  | fieldsAdd name=\"filtered\", type=\"processor\", component=filter, value=arraySum(filtered)\n  | fieldsKeep name, type, component, value\n]\n| append [\n  timeseries {sent=sum(otelcol_exporter_sent_metric_points)}, \n  by: { exporter },\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }  \n  | fieldsAdd name=\"sent\", type=\"exporter\", component=exporter, value=arraySum(sent)\n  | fieldsKeep name, type, component, value\n]\n| append [\n  timeseries {failed=sum(otelcol_exporter_send_failed_metric_points) }, \n  by: { exporter },\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }  \n  | fieldsAdd name=\"failed\", type=\"exporter\", component=exporter, value=arraySum(failed)\n  | fieldsKeep name, type, component, value\n]\n| fields name, type, component, value=toLong(value)",
+            "visualization": "table",
+            "visualizationSettings": {
+                "thresholds": [],
+                "chartSettings": {
+                    "xAxisScaling": "analyzedTimeframe",
+                    "gapPolicy": "connect",
+                    "circleChartSettings": {
+                        "groupingThresholdType": "relative",
+                        "groupingThresholdValue": 0,
+                        "valueType": "relative"
+                    },
+                    "categoryOverrides": {},
+                    "hiddenLegendFields": [],
+                    "categoricalBarChartSettings": {
+                        "categoryAxis": "name",
+                        "valueAxis": [
+                            "value"
+                        ],
+                        "categoryAxisLabel": "name",
+                        "valueAxisLabel": "value",
+                        "tooltipVariant": "single"
+                    },
+                    "truncationMode": "middle"
+                },
+                "singleValue": {
+                    "showLabel": true,
+                    "label": "",
+                    "prefixIcon": "",
+                    "autoscale": true,
+                    "alignment": "center",
+                    "colorThresholdTarget": "value",
+                    "recordField": "receiver"
+                },
+                "table": {
+                    "rowDensity": "condensed",
+                    "enableSparklines": false,
+                    "hiddenColumns": [],
+                    "lineWrapIds": [],
+                    "columnWidths": {
+                        "[\"name\"]": 158.89999389648438
+                    },
+                    "columnTypeOverrides": []
+                },
+                "honeycomb": {
+                    "shape": "hexagon",
+                    "legend": {
+                        "0": "a",
+                        "1": "u",
+                        "2": "t",
+                        "3": "o",
+                        "hidden": true
+                    },
+                    "dataMappings": {
+                        "value": "value"
+                    },
+                    "displayedFields": [
+                        "name",
+                        "type",
+                        "component"
+                    ],
+                    "colorMode": "color-palette",
+                    "colorPalette": "blue"
+                },
+                "histogram": {
+                    "dataMappings": [
+                        {
+                            "valueAxis": "value",
+                            "rangeAxis": ""
+                        }
+                    ]
+                },
+                "valueBoundaries": {
+                    "min": "auto",
+                    "max": "auto"
+                }
+            },
+            "querySettings": {
+                "maxResultRecords": 1000,
+                "defaultScanLimitGbytes": 500,
+                "maxResultMegaBytes": 1,
+                "defaultSamplingRatio": 10,
+                "enableSampling": false
+            },
+            "davis": {}
+        },
+        "80": {
+            "title": "Log record totals",
+            "description": "This tile shows how many logs have been accepted/refused by the receivers, and how many have been sent/failed by the exporters of the selected OpenTelemetry Collector instance. ",
+            "type": "data",
+            "query": "// This query retrieves how many logs have been accepted/refused by the receivers, and how many have been sent/failed by the exporters of the selected OpenTelemetry Collector instance. \ntimeseries { accepted=sum(otelcol_receiver_accepted_log_records) }, \n  by: { receiver },\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }\n  | fieldsAdd name=\"accepted\", type=\"receiver\", component=receiver, value=arraySum(accepted)\n  | fieldsKeep name, type, component, value\n| append [\n  timeseries {refused=sum(otelcol_receiver_refused_log_records) },\n  by: { receiver },\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }\n  | fieldsAdd name=\"refused\", type=\"receiver\", component=receiver, value=arraySum(refused)\n  | fieldsKeep name, type, component, value\n]\n| append [\n  timeseries {filtered=sum(otelcol_processor_filter_logs.filtered)},\n  by: {filter},\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }    \n  | fieldsAdd name=\"filtered\", type=\"processor\", component=filter, value=arraySum(filtered)\n  | fieldsKeep name, type, component, value\n]\n| append [\n  timeseries {sent=sum(otelcol_exporter_sent_log_records)}, \n  by: { exporter },\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }  \n  | fieldsAdd name=\"sent\", type=\"exporter\", component=exporter, value=arraySum(sent)\n  | fieldsKeep name, type, component, value\n]\n| append [\n  timeseries {failed=sum(otelcol_exporter_send_failed_log_records) }, \n  by: { exporter },\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }  \n  | fieldsAdd name=\"failed\", type=\"exporter\", component=exporter, value=arraySum(failed)\n  | fieldsKeep name, type, component, value\n]\n| fields name, type, component, value=toLong(value)",
+            "visualization": "table",
+            "visualizationSettings": {
+                "thresholds": [],
+                "chartSettings": {
+                    "xAxisScaling": "analyzedTimeframe",
+                    "gapPolicy": "connect",
+                    "circleChartSettings": {
+                        "groupingThresholdType": "relative",
+                        "groupingThresholdValue": 0,
+                        "valueType": "relative"
+                    },
+                    "categoryOverrides": {},
+                    "hiddenLegendFields": [],
+                    "categoricalBarChartSettings": {
+                        "categoryAxis": "name",
+                        "valueAxis": [
+                            "value"
+                        ],
+                        "categoryAxisLabel": "name",
+                        "valueAxisLabel": "value",
+                        "tooltipVariant": "single"
+                    },
+                    "truncationMode": "middle"
+                },
+                "singleValue": {
+                    "showLabel": true,
+                    "label": "",
+                    "prefixIcon": "",
+                    "autoscale": true,
+                    "alignment": "center",
+                    "colorThresholdTarget": "value",
+                    "recordField": "receiver"
+                },
+                "table": {
+                    "rowDensity": "condensed",
+                    "enableSparklines": false,
+                    "hiddenColumns": [],
+                    "lineWrapIds": [],
+                    "columnWidths": {
+                        "[\"name\"]": 158.89999389648438
+                    },
+                    "columnTypeOverrides": []
+                },
+                "honeycomb": {
+                    "shape": "hexagon",
+                    "legend": {
+                        "0": "a",
+                        "1": "u",
+                        "2": "t",
+                        "3": "o",
+                        "hidden": true
+                    },
+                    "dataMappings": {
+                        "value": "value"
+                    },
+                    "displayedFields": [
+                        "name",
+                        "type",
+                        "component"
+                    ],
+                    "colorMode": "color-palette",
+                    "colorPalette": "blue"
+                },
+                "histogram": {
+                    "dataMappings": [
+                        {
+                            "valueAxis": "value",
+                            "rangeAxis": ""
+                        }
+                    ]
+                },
+                "valueBoundaries": {
+                    "min": "auto",
+                    "max": "auto"
+                }
+            },
+            "querySettings": {
+                "maxResultRecords": 1000,
+                "defaultScanLimitGbytes": 500,
+                "maxResultMegaBytes": 1,
+                "defaultSamplingRatio": 10,
+                "enableSampling": false
+            },
+            "davis": {}
+        },
+        "88": {
+            "title": "Request size",
+            "description": "This tile shows a timeseries of the average incoming HTTP request size of  the OpenTelemetry Collector.",
+            "type": "data",
+            "query": "// This query retrieves a timeseries of the average incoming HTTP request size of  the OpenTelemetry Collector.\ntimeseries {avg=avg(http.server.request.size), max=max(http.server.request.size)},\n  by: {http.status_code},\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }",
+            "visualization": "lineChart",
+            "visualizationSettings": {
+                "thresholds": [],
+                "chartSettings": {
+                    "xAxisScaling": "analyzedTimeframe",
+                    "gapPolicy": "gap",
+                    "circleChartSettings": {
+                        "groupingThresholdType": "relative",
+                        "groupingThresholdValue": 0,
+                        "valueType": "relative"
+                    },
+                    "categoryOverrides": {},
+                    "categoricalBarChartSettings": {
+                        "categoryAxisLabel": "http.status_code",
+                        "valueAxisLabel": "interval",
+                        "categoryAxis": "http.status_code",
+                        "valueAxis": [
+                            "interval"
+                        ],
+                        "tooltipVariant": "single"
+                    },
+                    "hiddenLegendFields": [],
+                    "fieldMapping": {
+                        "timestamp": "timeframe",
+                        "leftAxisValues": [
+                            "avg",
+                            "max"
+                        ],
+                        "leftAxisDimensions": [
+                            "http.status_code"
+                        ]
+                    },
+                    "truncationMode": "middle",
+                    "bandChartSettings": {
+                        "lower": "avg",
+                        "upper": "max"
+                    },
+                    "xAxisLabel": "timeframe",
+                    "xAxisIsLabelVisible": false,
+                    "valueRepresentation": "absolute",
+                    "leftYAxisSettings": {}
+                },
+                "singleValue": {
+                    "showLabel": true,
+                    "label": "",
+                    "prefixIcon": "",
+                    "recordField": "net_peer_name",
+                    "autoscale": true,
+                    "alignment": "center",
+                    "colorThresholdTarget": "value"
+                },
+                "table": {
+                    "rowDensity": "condensed",
+                    "enableSparklines": false,
+                    "hiddenColumns": [],
+                    "lineWrapIds": [],
+                    "columnWidths": {},
+                    "columnTypeOverrides": [
+                        {
+                            "fields": [
+                                "avg",
+                                "max"
+                            ],
+                            "value": "sparkline",
+                            "id": 1744115263708
+                        }
+                    ]
+                },
+                "honeycomb": {
+                    "shape": "hexagon",
+                    "legend": "auto",
+                    "dataMappings": {
+                        "value": "interval"
+                    },
+                    "displayedFields": [
+                        "http.status_code"
+                    ],
+                    "colorMode": "color-palette",
+                    "colorPalette": "blue"
+                },
+                "histogram": {
+                    "dataMappings": [
+                        {
+                            "valueAxis": "interval",
+                            "rangeAxis": ""
+                        }
+                    ]
+                },
+                "valueBoundaries": {
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "unitsOverrides": [
+                    {
+                        "identifier": "RPC incoming",
+                        "unitCategory": "data",
+                        "baseUnit": "byte",
+                        "displayUnit": null,
+                        "decimals": 2,
+                        "suffix": "",
+                        "delimiter": false,
+                        "added": 1721215462564
+                    },
+                    {
+                        "identifier": "RPC outgoing",
+                        "unitCategory": "data",
+                        "baseUnit": "byte",
+                        "displayUnit": null,
+                        "decimals": 2,
+                        "suffix": "",
+                        "delimiter": false,
+                        "added": 1721215476940
+                    }
+                ]
+            },
+            "querySettings": {
+                "maxResultRecords": 1000,
+                "defaultScanLimitGbytes": 500,
+                "maxResultMegaBytes": 1,
+                "defaultSamplingRatio": 10,
+                "enableSampling": false
+            },
+            "davis": {}
+        },
+        "89": {
+            "title": "Request duration",
+            "description": "This tile shows a timeseries of the average incoming HTTP request duration of  the OpenTelemetry Collector.",
+            "type": "data",
+            "query": "// This query retrieves a timeseries of the average incoming HTTP request duration of  the OpenTelemetry Collector.\ntimeseries {avg=avg(http.server.duration), max=max(http.server.duration)},\n  by: {http.status_code},\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }",
+            "visualization": "lineChart",
+            "visualizationSettings": {
+                "thresholds": [],
+                "chartSettings": {
+                    "xAxisScaling": "analyzedTimeframe",
+                    "gapPolicy": "gap",
+                    "circleChartSettings": {
+                        "groupingThresholdType": "relative",
+                        "groupingThresholdValue": 0,
+                        "valueType": "relative"
+                    },
+                    "categoryOverrides": {},
+                    "categoricalBarChartSettings": {
+                        "categoryAxisLabel": "http.status_code",
+                        "valueAxisLabel": "interval",
+                        "categoryAxis": "http.status_code",
+                        "valueAxis": [
+                            "interval"
+                        ],
+                        "tooltipVariant": "single"
+                    },
+                    "fieldMapping": {
+                        "timestamp": "timeframe",
+                        "leftAxisValues": [
+                            "avg",
+                            "max"
+                        ],
+                        "leftAxisDimensions": [
+                            "http.status_code"
+                        ]
+                    },
+                    "hiddenLegendFields": [],
+                    "truncationMode": "middle",
+                    "bandChartSettings": {
+                        "lower": "avg",
+                        "upper": "max"
+                    },
+                    "xAxisLabel": "timeframe",
+                    "xAxisIsLabelVisible": false,
+                    "valueRepresentation": "absolute",
+                    "leftYAxisSettings": {
+                        "isLabelVisible": true,
+                        "label": "http.server.duration"
+                    }
+                },
+                "singleValue": {
+                    "showLabel": true,
+                    "label": "",
+                    "prefixIcon": "",
+                    "recordField": "service.name",
+                    "autoscale": true,
+                    "alignment": "center",
+                    "colorThresholdTarget": "value"
+                },
+                "table": {
+                    "rowDensity": "condensed",
+                    "enableSparklines": false,
+                    "hiddenColumns": [],
+                    "lineWrapIds": [],
+                    "columnWidths": {},
+                    "columnTypeOverrides": [
+                        {
+                            "fields": [
+                                "avg",
+                                "max"
+                            ],
+                            "value": "sparkline",
+                            "id": 1744115263761
+                        }
+                    ]
+                },
+                "honeycomb": {
+                    "shape": "hexagon",
+                    "legend": "auto",
+                    "dataMappings": {
+                        "value": "interval"
+                    },
+                    "displayedFields": [
+                        "http.status_code"
+                    ],
+                    "colorMode": "color-palette",
+                    "colorPalette": "blue"
+                },
+                "histogram": {
+                    "dataMappings": [
+                        {
+                            "valueAxis": "interval",
+                            "rangeAxis": ""
+                        }
+                    ]
+                },
+                "valueBoundaries": {
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "unitsOverrides": [
+                    {
+                        "identifier": "avg(http.server.duration)",
+                        "unitCategory": "time",
+                        "baseUnit": "millisecond",
+                        "displayUnit": null,
+                        "decimals": 2,
+                        "suffix": "",
+                        "delimiter": false,
+                        "added": 1721144587869
+                    }
+                ]
+            },
+            "querySettings": {
+                "maxResultRecords": 1000,
+                "defaultScanLimitGbytes": 500,
+                "maxResultMegaBytes": 1,
+                "defaultSamplingRatio": 10,
+                "enableSampling": false
+            },
+            "davis": {}
+        },
+        "90": {
+            "type": "markdown",
+            "content": "##### HTTP incoming"
+        },
+        "101": {
+            "title": "Total physical memory (resident set size)",
+            "description": "This tile shows a timeseries of the memory consumption of the OpenTelemetry Collector.",
+            "type": "data",
+            "query": "// This query retrieves a timeseries of the memory consumption of the OpenTelemetry Collector.\ntimeseries { avg(otelcol_process_memory_rss)},\n  by: { k8s.pod.name },\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }",
+            "visualization": "lineChart",
+            "visualizationSettings": {
+                "thresholds": [],
+                "chartSettings": {
+                    "xAxisScaling": "analyzedTimeframe",
+                    "gapPolicy": "connect",
+                    "circleChartSettings": {
+                        "groupingThresholdType": "relative",
+                        "groupingThresholdValue": 0,
+                        "valueType": "relative"
+                    },
+                    "categoryOverrides": {},
+                    "hiddenLegendFields": [],
+                    "fieldMapping": {
+                        "timestamp": "timeframe",
+                        "leftAxisValues": [
+                            "avg(otelcol_process_memory_rss)"
+                        ],
+                        "leftAxisDimensions": [
+                            "k8s.pod.name"
+                        ]
+                    },
+                    "leftYAxisSettings": {
+                        "max": "auto"
+                    },
+                    "categoricalBarChartSettings": {
+                        "categoryAxisLabel": "k8s.pod.name",
+                        "valueAxisLabel": "interval",
+                        "tooltipVariant": "single",
+                        "categoryAxis": "k8s.pod.name",
+                        "valueAxis": [
+                            "interval"
+                        ]
+                    },
+                    "legend": {
+                        "position": "bottom",
+                        "hidden": false
+                    },
+                    "truncationMode": "middle",
+                    "xAxisLabel": "timeframe",
+                    "xAxisIsLabelVisible": false,
+                    "valueRepresentation": "absolute"
+                },
+                "singleValue": {
+                    "showLabel": true,
+                    "label": "",
+                    "prefixIcon": "",
+                    "recordField": "service.name",
+                    "autoscale": true,
+                    "alignment": "center",
+                    "colorThresholdTarget": "value"
+                },
+                "table": {
+                    "rowDensity": "condensed",
+                    "enableSparklines": false,
+                    "hiddenColumns": [],
+                    "lineWrapIds": [],
+                    "columnWidths": {},
+                    "columnTypeOverrides": [
+                        {
+                            "fields": [
+                                "avg(otelcol_process_memory_rss)"
+                            ],
+                            "value": "sparkline",
+                            "id": 1744115568406
+                        }
+                    ]
+                },
+                "honeycomb": {
+                    "shape": "hexagon",
+                    "legend": "auto",
+                    "dataMappings": {
+                        "value": "interval"
+                    },
+                    "displayedFields": [
+                        "k8s.pod.name"
+                    ],
+                    "colorMode": "color-palette",
+                    "colorPalette": "blue"
+                },
+                "histogram": {
+                    "dataMappings": [
+                        {
+                            "valueAxis": "interval",
+                            "rangeAxis": ""
+                        }
+                    ]
+                },
+                "valueBoundaries": {
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "unitsOverrides": [
+                    {
+                        "identifier": "avg(process_memory_rss)",
+                        "unitCategory": "data",
+                        "baseUnit": "byte",
+                        "displayUnit": null,
+                        "decimals": 2,
+                        "suffix": "",
+                        "delimiter": false,
+                        "added": 1719570518103
+                    }
+                ]
+            },
+            "querySettings": {
+                "maxResultRecords": 1000,
+                "defaultScanLimitGbytes": 500,
+                "maxResultMegaBytes": 1,
+                "defaultSamplingRatio": 10,
+                "enableSampling": false
+            },
+            "davis": {}
+        },
+        "102": {
+            "title": "Total CPU user and system time",
+            "description": "This tile shows a timeseries of the CPU user and system time of the OpenTelemetry Collector.",
+            "type": "data",
+            "query": "// This query retrieves a timeseries of the CPU user and system time of the OpenTelemetry Collector.\ntimeseries average=avg(otelcol_process_cpu_seconds),\n  by: { k8s.pod.name },\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }",
+            "visualization": "lineChart",
+            "visualizationSettings": {
+                "thresholds": [],
+                "chartSettings": {
+                    "xAxisScaling": "analyzedTimeframe",
+                    "gapPolicy": "connect",
+                    "circleChartSettings": {
+                        "groupingThresholdType": "relative",
+                        "groupingThresholdValue": 0,
+                        "valueType": "relative"
+                    },
+                    "categoryOverrides": {},
+                    "hiddenLegendFields": [],
+                    "fieldMapping": {
+                        "timestamp": "timeframe",
+                        "leftAxisValues": [
+                            "average"
+                        ],
+                        "leftAxisDimensions": [
+                            "k8s.pod.name"
+                        ]
+                    },
+                    "categoricalBarChartSettings": {
+                        "categoryAxisLabel": "k8s.pod.name",
+                        "valueAxisLabel": "interval",
+                        "tooltipVariant": "single",
+                        "categoryAxis": "k8s.pod.name",
+                        "valueAxis": [
+                            "interval"
+                        ]
+                    },
+                    "legend": {
+                        "position": "bottom",
+                        "hidden": false
+                    },
+                    "truncationMode": "middle",
+                    "xAxisLabel": "timeframe",
+                    "xAxisIsLabelVisible": false,
+                    "valueRepresentation": "absolute",
+                    "leftYAxisSettings": {}
+                },
+                "singleValue": {
+                    "showLabel": true,
+                    "label": "",
+                    "prefixIcon": "",
+                    "recordField": "service.name",
+                    "autoscale": true,
+                    "alignment": "center",
+                    "colorThresholdTarget": "value"
+                },
+                "table": {
+                    "rowDensity": "condensed",
+                    "enableSparklines": false,
+                    "hiddenColumns": [],
+                    "lineWrapIds": [],
+                    "columnWidths": {},
+                    "columnTypeOverrides": [
+                        {
+                            "fields": [
+                                "average"
+                            ],
+                            "value": "sparkline",
+                            "id": 1744115588218
+                        }
+                    ]
+                },
+                "honeycomb": {
+                    "shape": "hexagon",
+                    "legend": "auto",
+                    "dataMappings": {
+                        "value": "interval"
+                    },
+                    "displayedFields": [
+                        "k8s.pod.name"
+                    ],
+                    "colorMode": "color-palette",
+                    "colorPalette": "blue"
+                },
+                "histogram": {
+                    "dataMappings": [
+                        {
+                            "valueAxis": "interval",
+                            "rangeAxis": ""
+                        }
+                    ]
+                },
+                "valueBoundaries": {
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "unitsOverrides": [
+                    {
+                        "identifier": "avg(process_cpu_seconds)",
+                        "unitCategory": "time",
+                        "baseUnit": "second",
+                        "displayUnit": null,
+                        "decimals": 2,
+                        "suffix": "",
+                        "delimiter": false,
+                        "added": 1719570588488
+                    }
+                ]
+            },
+            "querySettings": {
+                "maxResultRecords": 1000,
+                "defaultScanLimitGbytes": 500,
+                "maxResultMegaBytes": 1,
+                "defaultSamplingRatio": 10,
+                "enableSampling": false
+            },
+            "davis": {}
+        },
+        "105": {
+            "type": "markdown",
+            "content": "##### Queue size metrics"
+        },
+        "106": {
+            "title": "Exporter current queue size",
+            "description": "This tile shows a timeseries of the current exporter queue size of the OpenTelemetry Collector.",
+            "type": "data",
+            "query": "// This query retrieves a timeseries of the current exporter queue size of the OpenTelemetry Collector.\ntimeseries {max(otelcol_exporter_queue_size)}, \nby: { exporter },\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }",
+            "visualization": "lineChart",
+            "visualizationSettings": {
+                "thresholds": [],
+                "chartSettings": {
+                    "xAxisScaling": "analyzedTimeframe",
+                    "gapPolicy": "connect",
+                    "circleChartSettings": {
+                        "groupingThresholdType": "relative",
+                        "groupingThresholdValue": 0,
+                        "valueType": "relative"
+                    },
+                    "categoryOverrides": {},
+                    "hiddenLegendFields": [],
+                    "fieldMapping": {
+                        "timestamp": "timeframe",
+                        "leftAxisValues": [
+                            "max(otelcol_exporter_queue_size)"
+                        ],
+                        "leftAxisDimensions": [
+                            "exporter"
+                        ]
+                    },
+                    "leftYAxisSettings": {
+                        "max": "auto"
+                    },
+                    "categoricalBarChartSettings": {
+                        "categoryAxisLabel": "exporter",
+                        "valueAxisLabel": "interval",
+                        "categoryAxis": "exporter",
+                        "valueAxis": [
+                            "interval"
+                        ],
+                        "tooltipVariant": "single"
+                    },
+                    "truncationMode": "middle",
+                    "xAxisLabel": "timeframe",
+                    "xAxisIsLabelVisible": false,
+                    "valueRepresentation": "absolute"
+                },
+                "singleValue": {
+                    "showLabel": true,
+                    "label": "",
+                    "prefixIcon": "",
+                    "recordField": "service.name",
+                    "autoscale": true,
+                    "alignment": "center",
+                    "colorThresholdTarget": "value"
+                },
+                "table": {
+                    "rowDensity": "condensed",
+                    "enableSparklines": false,
+                    "hiddenColumns": [],
+                    "lineWrapIds": [],
+                    "columnWidths": {},
+                    "columnTypeOverrides": [
+                        {
+                            "fields": [
+                                "max(otelcol_exporter_queue_size)"
+                            ],
+                            "value": "sparkline",
+                            "id": 1742547291526
+                        }
+                    ]
+                },
+                "honeycomb": {
+                    "shape": "hexagon",
+                    "legend": "auto",
+                    "dataMappings": {
+                        "value": "interval"
+                    },
+                    "displayedFields": [
+                        "exporter"
+                    ],
+                    "colorMode": "color-palette",
+                    "colorPalette": "blue"
+                },
+                "histogram": {
+                    "dataMappings": [
+                        {
+                            "valueAxis": "interval",
+                            "rangeAxis": ""
+                        }
+                    ]
+                },
+                "valueBoundaries": {
+                    "min": "auto",
+                    "max": "auto"
+                }
+            },
+            "querySettings": {
+                "maxResultRecords": 1000,
+                "defaultScanLimitGbytes": 500,
+                "maxResultMegaBytes": 1,
+                "defaultSamplingRatio": 10,
+                "enableSampling": false
+            },
+            "davis": {}
+        },
+        "107": {
+            "title": "Exporter queue capacity",
+            "description": "This tile shows a timeseries of the exporter queue capacity of the OpenTelemetry Collector.",
+            "type": "data",
+            "query": "// This query retrieves a timeseries of the exporter queue capacity of the OpenTelemetry Collector.\ntimeseries {max(otelcol_exporter_queue_capacity)}, \nby: { exporter },\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }",
+            "visualization": "lineChart",
+            "visualizationSettings": {
+                "thresholds": [],
+                "chartSettings": {
+                    "xAxisScaling": "analyzedTimeframe",
+                    "gapPolicy": "connect",
+                    "circleChartSettings": {
+                        "groupingThresholdType": "relative",
+                        "groupingThresholdValue": 0,
+                        "valueType": "relative"
+                    },
+                    "categoryOverrides": {},
+                    "hiddenLegendFields": [],
+                    "fieldMapping": {
+                        "timestamp": "timeframe",
+                        "leftAxisValues": [
+                            "max(otelcol_exporter_queue_capacity)"
+                        ],
+                        "leftAxisDimensions": [
+                            "exporter"
+                        ]
+                    },
+                    "leftYAxisSettings": {
+                        "max": "auto"
+                    },
+                    "categoricalBarChartSettings": {
+                        "categoryAxisLabel": "exporter",
+                        "valueAxisLabel": "interval",
+                        "categoryAxis": "exporter",
+                        "valueAxis": [
+                            "interval"
+                        ],
+                        "tooltipVariant": "single"
+                    },
+                    "truncationMode": "middle",
+                    "xAxisLabel": "timeframe",
+                    "xAxisIsLabelVisible": false,
+                    "valueRepresentation": "absolute"
+                },
+                "singleValue": {
+                    "showLabel": true,
+                    "label": "",
+                    "prefixIcon": "",
+                    "recordField": "service.name",
+                    "autoscale": true,
+                    "alignment": "center",
+                    "colorThresholdTarget": "value"
+                },
+                "table": {
+                    "rowDensity": "condensed",
+                    "enableSparklines": false,
+                    "hiddenColumns": [],
+                    "lineWrapIds": [],
+                    "columnWidths": {},
+                    "columnTypeOverrides": [
+                        {
+                            "fields": [
+                                "max(otelcol_exporter_queue_capacity)"
+                            ],
+                            "value": "sparkline",
+                            "id": 1742547291489
+                        }
+                    ]
+                },
+                "honeycomb": {
+                    "shape": "hexagon",
+                    "legend": "auto",
+                    "dataMappings": {
+                        "value": "interval"
+                    },
+                    "displayedFields": [
+                        "exporter"
+                    ],
+                    "colorMode": "color-palette",
+                    "colorPalette": "blue"
+                },
+                "histogram": {
+                    "dataMappings": [
+                        {
+                            "valueAxis": "interval",
+                            "rangeAxis": ""
+                        }
+                    ]
+                },
+                "valueBoundaries": {
+                    "min": "auto",
+                    "max": "auto"
+                }
+            },
+            "querySettings": {
+                "maxResultRecords": 1000,
+                "defaultScanLimitGbytes": 500,
+                "maxResultMegaBytes": 1,
+                "defaultSamplingRatio": 10,
+                "enableSampling": false
+            },
+            "davis": {}
+        },
+        "108": {
+            "type": "markdown",
+            "content": "### Batch metrics\nThese are metrics reported by the [batchprocessor](https://github.com/open-telemetry/opentelemetry-collector/blob/main/processor/batchprocessor/README.md), if used. They can be used to understand batching behavior."
+        },
+        "109": {
+            "title": "Batch size (items)",
+            "description": "This tile shows a timeseries of the batch size (in items) of the OpenTelemetry Collector.",
+            "type": "data",
+            "query": "// This query retrieves a timeseries of the batch size (in items) of the OpenTelemetry Collector.\ntimeseries {max=max(otelcol_processor_batch_batch_send_size), avg=avg(otelcol_processor_batch_batch_send_size)}, \n  by: {processor},\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }",
+            "visualization": "lineChart",
+            "visualizationSettings": {
+                "thresholds": [],
+                "chartSettings": {
+                    "xAxisScaling": "analyzedTimeframe",
+                    "gapPolicy": "connect",
+                    "circleChartSettings": {
+                        "groupingThresholdType": "relative",
+                        "groupingThresholdValue": 0,
+                        "valueType": "relative"
+                    },
+                    "categoryOverrides": {},
+                    "hiddenLegendFields": [],
+                    "fieldMapping": {
+                        "timestamp": "timeframe",
+                        "leftAxisValues": [
+                            "max",
+                            "avg"
+                        ],
+                        "leftAxisDimensions": [
+                            "processor"
+                        ]
+                    },
+                    "categoricalBarChartSettings": {
+                        "categoryAxisLabel": "processor",
+                        "valueAxisLabel": "interval",
+                        "categoryAxis": "processor",
+                        "valueAxis": [
+                            "interval"
+                        ],
+                        "tooltipVariant": "single"
+                    },
+                    "truncationMode": "middle",
+                    "bandChartSettings": {
+                        "lower": "avg",
+                        "upper": "max"
+                    },
+                    "xAxisLabel": "timeframe",
+                    "xAxisIsLabelVisible": false,
+                    "valueRepresentation": "absolute",
+                    "leftYAxisSettings": {
+                        "isLabelVisible": true,
+                        "label": "otelcol_processor_batch_batch_send_size"
+                    }
+                },
+                "singleValue": {
+                    "showLabel": true,
+                    "label": "",
+                    "prefixIcon": "",
+                    "autoscale": true,
+                    "alignment": "center",
+                    "colorThresholdTarget": "value",
+                    "recordField": "service.name"
+                },
+                "table": {
+                    "rowDensity": "condensed",
+                    "enableSparklines": false,
+                    "hiddenColumns": [],
+                    "lineWrapIds": [],
+                    "columnWidths": {},
+                    "columnTypeOverrides": [
+                        {
+                            "fields": [
+                                "max",
+                                "avg"
+                            ],
+                            "value": "sparkline",
+                            "id": 1742547291320
+                        }
+                    ]
+                },
+                "honeycomb": {
+                    "shape": "hexagon",
+                    "legend": "auto",
+                    "dataMappings": {
+                        "value": "interval"
+                    },
+                    "displayedFields": [
+                        "processor"
+                    ],
+                    "colorMode": "color-palette",
+                    "colorPalette": "blue"
+                },
+                "histogram": {
+                    "dataMappings": [
+                        {
+                            "valueAxis": "interval",
+                            "rangeAxis": ""
+                        }
+                    ]
+                },
+                "valueBoundaries": {
+                    "min": "auto",
+                    "max": "auto"
+                }
+            },
+            "querySettings": {
+                "maxResultRecords": 1000,
+                "defaultScanLimitGbytes": 500,
+                "maxResultMegaBytes": 1,
+                "defaultSamplingRatio": 10,
+                "enableSampling": false
+            },
+            "davis": {
+                "enabled": false,
+                "davisVisualization": {
+                    "isAvailable": true
+                }
+            }
+        },
+        "117": {
+            "type": "markdown",
+            "content": "##### HTTP outgoing"
+        },
+        "118": {
+            "title": "Request count",
+            "description": "This tile shows a timeseries of the outgoing HTTP request count of  the OpenTelemetry Collector.",
+            "type": "data",
+            "query": "// This query retrieves a timeseries of the outgoing HTTP request count of  the OpenTelemetry Collector.\ntimeseries { sum(http.client.duration, rollup:count) },\n  by: { http.status_code },\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }",
+            "visualization": "lineChart",
+            "visualizationSettings": {
+                "thresholds": [],
+                "chartSettings": {
+                    "xAxisScaling": "analyzedTimeframe",
+                    "gapPolicy": "gap",
+                    "circleChartSettings": {
+                        "groupingThresholdType": "relative",
+                        "groupingThresholdValue": 0,
+                        "valueType": "relative"
+                    },
+                    "categoryOverrides": {},
+                    "categoricalBarChartSettings": {
+                        "categoryAxisLabel": "http.status_code",
+                        "valueAxisLabel": "interval",
+                        "categoryAxis": "http.status_code",
+                        "valueAxis": [
+                            "interval"
+                        ],
+                        "tooltipVariant": "single"
+                    },
+                    "fieldMapping": {
+                        "timestamp": "timeframe",
+                        "leftAxisValues": [
+                            "sum(http.client.duration, rollup:total)"
+                        ],
+                        "leftAxisDimensions": [
+                            "http.status_code"
+                        ]
+                    },
+                    "hiddenLegendFields": [],
+                    "truncationMode": "middle",
+                    "xAxisLabel": "timeframe",
+                    "xAxisIsLabelVisible": false,
+                    "valueRepresentation": "absolute",
+                    "leftYAxisSettings": {}
+                },
+                "singleValue": {
+                    "showLabel": true,
+                    "label": "",
+                    "prefixIcon": "",
+                    "recordField": "service.name",
+                    "autoscale": true,
+                    "alignment": "center",
+                    "colorThresholdTarget": "value"
+                },
+                "table": {
+                    "rowDensity": "condensed",
+                    "enableSparklines": false,
+                    "hiddenColumns": [],
+                    "lineWrapIds": [],
+                    "columnWidths": {},
+                    "columnTypeOverrides": [
+                        {
+                            "fields": [
+                                "sum(http.client.duration, rollup:total)"
+                            ],
+                            "value": "sparkline",
+                            "id": 1744115263900
+                        }
+                    ]
+                },
+                "honeycomb": {
+                    "shape": "hexagon",
+                    "legend": "auto",
+                    "dataMappings": {
+                        "value": "interval"
+                    },
+                    "displayedFields": [
+                        "http.status_code"
+                    ],
+                    "colorMode": "color-palette",
+                    "colorPalette": "blue"
+                },
+                "histogram": {
+                    "dataMappings": [
+                        {
+                            "valueAxis": "interval",
+                            "rangeAxis": ""
+                        }
+                    ]
+                },
+                "valueBoundaries": {
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "unitsOverrides": []
+            },
+            "querySettings": {
+                "maxResultRecords": 1000,
+                "defaultScanLimitGbytes": 500,
+                "maxResultMegaBytes": 1,
+                "defaultSamplingRatio": 10,
+                "enableSampling": false
+            },
+            "davis": {}
+        },
+        "119": {
+            "title": "Request size",
+            "description": "This tile shows a timeseries of the average outgoing HTTP request size of  the OpenTelemetry Collector.",
+            "type": "data",
+            "query": "// This query retrieves a timeseries of the average outgoing HTTP request size of  the OpenTelemetry Collector.\ntimeseries {avg=avg(http.client.request.size), max=max(http.client.request.size)},\n  by: {http.status_code},\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }",
+            "visualization": "lineChart",
+            "visualizationSettings": {
+                "thresholds": [],
+                "chartSettings": {
+                    "xAxisScaling": "analyzedTimeframe",
+                    "gapPolicy": "gap",
+                    "circleChartSettings": {
+                        "groupingThresholdType": "relative",
+                        "groupingThresholdValue": 0,
+                        "valueType": "relative"
+                    },
+                    "categoryOverrides": {},
+                    "categoricalBarChartSettings": {
+                        "categoryAxisLabel": "http.status_code",
+                        "valueAxisLabel": "interval",
+                        "categoryAxis": "http.status_code",
+                        "valueAxis": [
+                            "interval"
+                        ],
+                        "tooltipVariant": "single"
+                    },
+                    "hiddenLegendFields": [],
+                    "fieldMapping": {
+                        "timestamp": "timeframe",
+                        "leftAxisValues": [
+                            "avg",
+                            "max"
+                        ],
+                        "leftAxisDimensions": [
+                            "http.status_code"
+                        ]
+                    },
+                    "bandChartSettings": {
+                        "lower": "avg",
+                        "upper": "max"
+                    },
+                    "truncationMode": "middle",
+                    "xAxisLabel": "timeframe",
+                    "xAxisIsLabelVisible": false,
+                    "valueRepresentation": "absolute",
+                    "leftYAxisSettings": {}
+                },
+                "singleValue": {
+                    "showLabel": true,
+                    "label": "",
+                    "prefixIcon": "",
+                    "recordField": "net_peer_name",
+                    "autoscale": true,
+                    "alignment": "center",
+                    "colorThresholdTarget": "value"
+                },
+                "table": {
+                    "rowDensity": "condensed",
+                    "enableSparklines": false,
+                    "hiddenColumns": [],
+                    "lineWrapIds": [],
+                    "columnWidths": {},
+                    "columnTypeOverrides": [
+                        {
+                            "fields": [
+                                "avg",
+                                "max"
+                            ],
+                            "value": "sparkline",
+                            "id": 1744115263859
+                        }
+                    ]
+                },
+                "honeycomb": {
+                    "shape": "hexagon",
+                    "legend": "auto",
+                    "dataMappings": {
+                        "value": "interval"
+                    },
+                    "displayedFields": [
+                        "http.status_code"
+                    ],
+                    "colorMode": "color-palette",
+                    "colorPalette": "blue"
+                },
+                "histogram": {
+                    "dataMappings": [
+                        {
+                            "valueAxis": "interval",
+                            "rangeAxis": ""
+                        }
+                    ]
+                },
+                "valueBoundaries": {
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "unitsOverrides": []
+            },
+            "querySettings": {
+                "maxResultRecords": 1000,
+                "defaultScanLimitGbytes": 500,
+                "maxResultMegaBytes": 1,
+                "defaultSamplingRatio": 10,
+                "enableSampling": false
+            },
+            "davis": {}
+        },
+        "120": {
+            "title": "Request duration",
+            "description": "This tile shows a timeseries of the average outgoing HTTP request duration of  the OpenTelemetry Collector.",
+            "type": "data",
+            "query": "// This query retrieves a timeseries of the average outgoing HTTP request duration of  the OpenTelemetry Collector.\ntimeseries {avg=avg(http.client.duration), max=max(http.client.duration)},\n  by: {http.status_code},\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }",
+            "visualization": "lineChart",
+            "visualizationSettings": {
+                "thresholds": [],
+                "chartSettings": {
+                    "xAxisScaling": "analyzedTimeframe",
+                    "gapPolicy": "gap",
+                    "circleChartSettings": {
+                        "groupingThresholdType": "relative",
+                        "groupingThresholdValue": 0,
+                        "valueType": "relative"
+                    },
+                    "categoryOverrides": {},
+                    "categoricalBarChartSettings": {
+                        "categoryAxisLabel": "http.status_code",
+                        "valueAxisLabel": "interval",
+                        "categoryAxis": "http.status_code",
+                        "valueAxis": [
+                            "interval"
+                        ],
+                        "tooltipVariant": "single"
+                    },
+                    "fieldMapping": {
+                        "timestamp": "timeframe",
+                        "leftAxisValues": [
+                            "avg",
+                            "max"
+                        ],
+                        "leftAxisDimensions": [
+                            "http.status_code"
+                        ]
+                    },
+                    "hiddenLegendFields": [],
+                    "bandChartSettings": {
+                        "lower": "avg",
+                        "upper": "max"
+                    },
+                    "truncationMode": "middle",
+                    "xAxisLabel": "timeframe",
+                    "xAxisIsLabelVisible": false,
+                    "valueRepresentation": "absolute",
+                    "leftYAxisSettings": {
+                        "isLabelVisible": true,
+                        "label": "http.client.duration"
+                    }
+                },
+                "singleValue": {
+                    "showLabel": true,
+                    "label": "",
+                    "prefixIcon": "",
+                    "recordField": "service.name",
+                    "autoscale": true,
+                    "alignment": "center",
+                    "colorThresholdTarget": "value"
+                },
+                "table": {
+                    "rowDensity": "condensed",
+                    "enableSparklines": false,
+                    "hiddenColumns": [],
+                    "lineWrapIds": [],
+                    "columnWidths": {},
+                    "columnTypeOverrides": [
+                        {
+                            "fields": [
+                                "avg",
+                                "max"
+                            ],
+                            "value": "sparkline",
+                            "id": 1744115263810
+                        }
+                    ]
+                },
+                "honeycomb": {
+                    "shape": "hexagon",
+                    "legend": "auto",
+                    "dataMappings": {
+                        "value": "interval"
+                    },
+                    "displayedFields": [
+                        "http.status_code"
+                    ],
+                    "colorMode": "color-palette",
+                    "colorPalette": "blue"
+                },
+                "histogram": {
+                    "dataMappings": [
+                        {
+                            "valueAxis": "interval",
+                            "rangeAxis": ""
+                        }
+                    ]
+                },
+                "valueBoundaries": {
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "unitsOverrides": [
+                    {
+                        "identifier": "avg(http.client.duration)",
+                        "unitCategory": "time",
+                        "baseUnit": "millisecond",
+                        "displayUnit": null,
+                        "decimals": 2,
+                        "suffix": "",
+                        "delimiter": false,
+                        "added": 1721144587869
+                    }
+                ]
+            },
+            "querySettings": {
+                "maxResultRecords": 1000,
+                "defaultScanLimitGbytes": 500,
+                "maxResultMegaBytes": 1,
+                "defaultSamplingRatio": 10,
+                "enableSampling": false
+            },
+            "davis": {}
+        },
+        "121": {
+            "type": "markdown",
+            "content": "##### RPC incoming"
+        },
+        "122": {
+            "title": "Request count",
+            "description": "This tile shows a timeseries of the incoming RPC request count of  the OpenTelemetry Collector.",
+            "type": "data",
+            "query": "// This query retrieves a timeseries of the incoming RPC request count of  the OpenTelemetry Collector.\ntimeseries { sum(rpc.server.duration, rollup:count) },\n  by: { rpc.grpc.status_code },\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }",
+            "visualization": "lineChart",
+            "visualizationSettings": {
+                "thresholds": [],
+                "chartSettings": {
+                    "xAxisScaling": "analyzedTimeframe",
+                    "gapPolicy": "gap",
+                    "circleChartSettings": {
+                        "groupingThresholdType": "relative",
+                        "groupingThresholdValue": 0,
+                        "valueType": "relative"
+                    },
+                    "categoryOverrides": {},
+                    "categoricalBarChartSettings": {
+                        "categoryAxisLabel": "rpc.grpc.status_code",
+                        "valueAxisLabel": "interval",
+                        "categoryAxis": "rpc.grpc.status_code",
+                        "valueAxis": [
+                            "interval"
+                        ],
+                        "tooltipVariant": "single"
+                    },
+                    "fieldMapping": {
+                        "timestamp": "timeframe",
+                        "leftAxisValues": [
+                            "sum(rpc.server.duration, rollup:total)"
+                        ],
+                        "leftAxisDimensions": [
+                            "rpc.grpc.status_code"
+                        ]
+                    },
+                    "hiddenLegendFields": [],
+                    "truncationMode": "middle"
+                },
+                "singleValue": {
+                    "showLabel": true,
+                    "label": "",
+                    "prefixIcon": "",
+                    "recordField": "service.name",
+                    "autoscale": true,
+                    "alignment": "center",
+                    "colorThresholdTarget": "value"
+                },
+                "table": {
+                    "rowDensity": "condensed",
+                    "enableSparklines": false,
+                    "hiddenColumns": [],
+                    "lineWrapIds": [],
+                    "columnWidths": {}
+                },
+                "honeycomb": {
+                    "shape": "hexagon",
+                    "legend": "auto",
+                    "dataMappings": {
+                        "value": "interval"
+                    },
+                    "displayedFields": [
+                        "rpc.grpc.status_code"
+                    ],
+                    "colorMode": "color-palette",
+                    "colorPalette": "blue"
+                },
+                "histogram": {
+                    "dataMappings": [
+                        {
+                            "valueAxis": "interval",
+                            "rangeAxis": ""
+                        }
+                    ]
+                },
+                "valueBoundaries": {
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "unitsOverrides": []
+            },
+            "querySettings": {
+                "maxResultRecords": 1000,
+                "defaultScanLimitGbytes": 500,
+                "maxResultMegaBytes": 1,
+                "defaultSamplingRatio": 10,
+                "enableSampling": false
+            },
+            "davis": {}
+        },
+        "123": {
+            "title": "Request size",
+            "description": "This tile shows a timeseries of the average incoming RPC request size of  the OpenTelemetry Collector.",
+            "type": "data",
+            "query": "// This query retrieves a timeseries of the average incoming RPC request size of  the OpenTelemetry Collector.\ntimeseries {avg=avg(rpc.server.request.size), max=max(rpc.server.request.size)},\n  // by: { rpc.grpc.status_code },\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }",
+            "visualization": "lineChart",
+            "visualizationSettings": {
+                "thresholds": [],
+                "chartSettings": {
+                    "xAxisScaling": "analyzedTimeframe",
+                    "gapPolicy": "gap",
+                    "circleChartSettings": {
+                        "groupingThresholdType": "relative",
+                        "groupingThresholdValue": 0,
+                        "valueType": "relative"
+                    },
+                    "categoryOverrides": {},
+                    "categoricalBarChartSettings": {
+                        "categoryAxisLabel": "http.status_code",
+                        "valueAxisLabel": "interval",
+                        "tooltipVariant": "single"
+                    },
+                    "hiddenLegendFields": [],
+                    "fieldMapping": {
+                        "timestamp": "timeframe",
+                        "leftAxisValues": [
+                            "avg",
+                            "max"
+                        ],
+                        "leftAxisDimensions": []
+                    },
+                    "bandChartSettings": {
+                        "lower": "avg",
+                        "upper": "max",
+                        "time": "timeframe"
+                    },
+                    "truncationMode": "middle"
+                },
+                "singleValue": {
+                    "showLabel": true,
+                    "label": "",
+                    "prefixIcon": "",
+                    "recordField": "net_peer_name",
+                    "autoscale": true,
+                    "alignment": "center",
+                    "colorThresholdTarget": "value"
+                },
+                "table": {
+                    "rowDensity": "condensed",
+                    "enableSparklines": false,
+                    "hiddenColumns": [],
+                    "lineWrapIds": [],
+                    "columnWidths": {}
+                },
+                "honeycomb": {
+                    "shape": "hexagon",
+                    "legend": "auto",
+                    "dataMappings": {
+                        "value": "interval"
+                    },
+                    "displayedFields": [
+                        null
+                    ],
+                    "colorMode": "color-palette",
+                    "colorPalette": "blue"
+                },
+                "histogram": {
+                    "dataMappings": [
+                        {
+                            "valueAxis": "interval",
+                            "rangeAxis": ""
+                        }
+                    ]
+                },
+                "valueBoundaries": {
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "unitsOverrides": [
+                    {
+                        "identifier": "RPC incoming",
+                        "unitCategory": "data",
+                        "baseUnit": "byte",
+                        "displayUnit": null,
+                        "decimals": 2,
+                        "suffix": "",
+                        "delimiter": false,
+                        "added": 1721215462564
+                    },
+                    {
+                        "identifier": "RPC outgoing",
+                        "unitCategory": "data",
+                        "baseUnit": "byte",
+                        "displayUnit": null,
+                        "decimals": 2,
+                        "suffix": "",
+                        "delimiter": false,
+                        "added": 1721215476940
+                    }
+                ]
+            },
+            "querySettings": {
+                "maxResultRecords": 1000,
+                "defaultScanLimitGbytes": 500,
+                "maxResultMegaBytes": 1,
+                "defaultSamplingRatio": 10,
+                "enableSampling": false
+            },
+            "davis": {},
+            "timeframe": {
+                "tileTimeframe": {
+                    "from": "now()-2h",
+                    "to": "now()"
+                },
+                "tileTimeframeEnabled": false
+            }
+        },
+        "124": {
+            "title": "Request duration",
+            "description": "This tile shows a timeseries of the average incoming RPC request duration of  the OpenTelemetry Collector.",
+            "type": "data",
+            "query": "// This query retrieves a timeseries of the average incoming RPC request duration of  the OpenTelemetry Collector.\ntimeseries {avg=avg(rpc.server.duration), max=max(rpc.server.duration)},\n  by: { rpc.grpc.status_code },\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }",
+            "visualization": "lineChart",
+            "visualizationSettings": {
+                "thresholds": [],
+                "chartSettings": {
+                    "xAxisScaling": "analyzedTimeframe",
+                    "gapPolicy": "gap",
+                    "circleChartSettings": {
+                        "groupingThresholdType": "relative",
+                        "groupingThresholdValue": 0,
+                        "valueType": "relative"
+                    },
+                    "categoryOverrides": {},
+                    "categoricalBarChartSettings": {
+                        "categoryAxisLabel": "rpc.grpc.status_code",
+                        "valueAxisLabel": "interval",
+                        "categoryAxis": "rpc.grpc.status_code",
+                        "valueAxis": [
+                            "interval"
+                        ],
+                        "tooltipVariant": "single"
+                    },
+                    "fieldMapping": {
+                        "timestamp": "timeframe",
+                        "leftAxisValues": [
+                            "avg",
+                            "max"
+                        ],
+                        "leftAxisDimensions": [
+                            "rpc.grpc.status_code"
+                        ]
+                    },
+                    "hiddenLegendFields": [],
+                    "bandChartSettings": {
+                        "lower": "avg",
+                        "upper": "max",
+                        "time": "timeframe"
+                    },
+                    "truncationMode": "middle"
+                },
+                "singleValue": {
+                    "showLabel": true,
+                    "label": "",
+                    "prefixIcon": "",
+                    "recordField": "service.name",
+                    "autoscale": true,
+                    "alignment": "center",
+                    "colorThresholdTarget": "value"
+                },
+                "table": {
+                    "rowDensity": "condensed",
+                    "enableSparklines": false,
+                    "hiddenColumns": [],
+                    "lineWrapIds": [],
+                    "columnWidths": {}
+                },
+                "honeycomb": {
+                    "shape": "hexagon",
+                    "legend": "auto",
+                    "dataMappings": {
+                        "value": "interval"
+                    },
+                    "displayedFields": [
+                        "rpc.grpc.status_code"
+                    ],
+                    "colorMode": "color-palette",
+                    "colorPalette": "blue"
+                },
+                "histogram": {
+                    "dataMappings": [
+                        {
+                            "valueAxis": "interval",
+                            "rangeAxis": ""
+                        }
+                    ]
+                },
+                "valueBoundaries": {
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "unitsOverrides": [
+                    {
+                        "identifier": "avg(rpc.server.duration)",
+                        "unitCategory": "time",
+                        "baseUnit": "millisecond",
+                        "displayUnit": null,
+                        "decimals": 2,
+                        "suffix": "",
+                        "delimiter": false,
+                        "added": 1721144587869
+                    }
+                ]
+            },
+            "querySettings": {
+                "maxResultRecords": 1000,
+                "defaultScanLimitGbytes": 500,
+                "maxResultMegaBytes": 1,
+                "defaultSamplingRatio": 10,
+                "enableSampling": false
+            },
+            "davis": {}
+        },
+        "125": {
+            "type": "markdown",
+            "content": "##### RPC outgoing"
+        },
+        "126": {
+            "title": "Request count",
+            "description": "This tile shows a timeseries of the outgoing RPC request count of  the OpenTelemetry Collector.",
+            "type": "data",
+            "query": "// This query retrieves a timeseries of the outgoing RPC request count of  the OpenTelemetry Collector.\ntimeseries { sum(rpc.client.duration, rollup:count) },\n  by: { rpc.grpc.status_code },\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }",
+            "visualization": "lineChart",
+            "visualizationSettings": {
+                "thresholds": [],
+                "chartSettings": {
+                    "xAxisScaling": "analyzedTimeframe",
+                    "gapPolicy": "gap",
+                    "circleChartSettings": {
+                        "groupingThresholdType": "relative",
+                        "groupingThresholdValue": 0,
+                        "valueType": "relative"
+                    },
+                    "categoryOverrides": {},
+                    "categoricalBarChartSettings": {
+                        "categoryAxisLabel": "rpc.grpc.status_code",
+                        "valueAxisLabel": "interval",
+                        "categoryAxis": "rpc.grpc.status_code",
+                        "valueAxis": [
+                            "interval"
+                        ],
+                        "tooltipVariant": "single"
+                    },
+                    "fieldMapping": {
+                        "timestamp": "timeframe",
+                        "leftAxisValues": [
+                            "sum(rpc.client.duration, rollup:total)"
+                        ],
+                        "leftAxisDimensions": [
+                            "rpc.grpc.status_code"
+                        ]
+                    },
+                    "hiddenLegendFields": [],
+                    "truncationMode": "middle"
+                },
+                "singleValue": {
+                    "showLabel": true,
+                    "label": "",
+                    "prefixIcon": "",
+                    "recordField": "service.name",
+                    "autoscale": true,
+                    "alignment": "center",
+                    "colorThresholdTarget": "value"
+                },
+                "table": {
+                    "rowDensity": "condensed",
+                    "enableSparklines": false,
+                    "hiddenColumns": [],
+                    "lineWrapIds": [],
+                    "columnWidths": {}
+                },
+                "honeycomb": {
+                    "shape": "hexagon",
+                    "legend": "auto",
+                    "dataMappings": {
+                        "value": "interval"
+                    },
+                    "displayedFields": [
+                        "rpc.grpc.status_code"
+                    ],
+                    "colorMode": "color-palette",
+                    "colorPalette": "blue"
+                },
+                "histogram": {
+                    "dataMappings": [
+                        {
+                            "valueAxis": "interval",
+                            "rangeAxis": ""
+                        }
+                    ]
+                },
+                "valueBoundaries": {
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "unitsOverrides": []
+            },
+            "querySettings": {
+                "maxResultRecords": 1000,
+                "defaultScanLimitGbytes": 500,
+                "maxResultMegaBytes": 1,
+                "defaultSamplingRatio": 10,
+                "enableSampling": false
+            },
+            "davis": {}
+        },
+        "127": {
+            "title": "Request duration",
+            "description": "This tile shows a timeseries of the average outgoing RPC request duration of  the OpenTelemetry Collector.",
+            "type": "data",
+            "query": "// This query retrieves a timeseries of the average outgoing RPC request duration of  the OpenTelemetry Collector.\ntimeseries {avg=avg(rpc.client.duration), max=max(rpc.client.duration)},\n  by: { rpc.grpc.status_code },\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }",
+            "visualization": "lineChart",
+            "visualizationSettings": {
+                "thresholds": [],
+                "chartSettings": {
+                    "xAxisScaling": "analyzedTimeframe",
+                    "gapPolicy": "gap",
+                    "circleChartSettings": {
+                        "groupingThresholdType": "relative",
+                        "groupingThresholdValue": 0,
+                        "valueType": "relative"
+                    },
+                    "categoryOverrides": {},
+                    "categoricalBarChartSettings": {
+                        "categoryAxisLabel": "rpc.grpc.status_code",
+                        "valueAxisLabel": "interval",
+                        "categoryAxis": "rpc.grpc.status_code",
+                        "valueAxis": [
+                            "interval"
+                        ],
+                        "tooltipVariant": "single"
+                    },
+                    "fieldMapping": {
+                        "timestamp": "timeframe",
+                        "leftAxisValues": [
+                            "avg",
+                            "max"
+                        ],
+                        "leftAxisDimensions": [
+                            "rpc.grpc.status_code"
+                        ]
+                    },
+                    "hiddenLegendFields": [],
+                    "bandChartSettings": {
+                        "lower": "avg",
+                        "upper": "max",
+                        "time": "timeframe"
+                    },
+                    "truncationMode": "middle"
+                },
+                "singleValue": {
+                    "showLabel": true,
+                    "label": "",
+                    "prefixIcon": "",
+                    "recordField": "service.name",
+                    "autoscale": true,
+                    "alignment": "center",
+                    "colorThresholdTarget": "value"
+                },
+                "table": {
+                    "rowDensity": "condensed",
+                    "enableSparklines": false,
+                    "hiddenColumns": [],
+                    "lineWrapIds": [],
+                    "columnWidths": {}
+                },
+                "honeycomb": {
+                    "shape": "hexagon",
+                    "legend": "auto",
+                    "dataMappings": {
+                        "value": "interval"
+                    },
+                    "displayedFields": [
+                        "rpc.grpc.status_code"
+                    ],
+                    "colorMode": "color-palette",
+                    "colorPalette": "blue"
+                },
+                "histogram": {
+                    "dataMappings": [
+                        {
+                            "valueAxis": "interval",
+                            "rangeAxis": ""
+                        }
+                    ]
+                },
+                "valueBoundaries": {
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "unitsOverrides": [
+                    {
+                        "identifier": "avg(rpc.client.duration)",
+                        "unitCategory": "time",
+                        "baseUnit": "millisecond",
+                        "displayUnit": null,
+                        "decimals": 2,
+                        "suffix": "",
+                        "delimiter": false,
+                        "added": 1721144587869
+                    }
+                ]
+            },
+            "querySettings": {
+                "maxResultRecords": 1000,
+                "defaultScanLimitGbytes": 500,
+                "maxResultMegaBytes": 1,
+                "defaultSamplingRatio": 10,
+                "enableSampling": false
+            },
+            "davis": {}
+        },
+        "128": {
+            "title": "Request size",
+            "description": "This tile shows a timeseries of the average outgoing RPC request size of  the OpenTelemetry Collector.",
+            "type": "data",
+            "query": "// This query retrieves a timeseries of the average outgoing RPC request size of  the OpenTelemetry Collector.\ntimeseries {avg=avg(rpc.client.request.size), max=max(rpc.client.request.size)},\n  // by: { rpc.grpc.status_code },\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }",
+            "visualization": "lineChart",
+            "visualizationSettings": {
+                "thresholds": [],
+                "chartSettings": {
+                    "xAxisScaling": "analyzedTimeframe",
+                    "gapPolicy": "gap",
+                    "circleChartSettings": {
+                        "groupingThresholdType": "relative",
+                        "groupingThresholdValue": 0,
+                        "valueType": "relative"
+                    },
+                    "categoryOverrides": {},
+                    "categoricalBarChartSettings": {
+                        "categoryAxisLabel": "http.status_code",
+                        "valueAxisLabel": "interval",
+                        "tooltipVariant": "single"
+                    },
+                    "hiddenLegendFields": [],
+                    "fieldMapping": {
+                        "timestamp": "timeframe",
+                        "leftAxisValues": [
+                            "avg",
+                            "max"
+                        ],
+                        "leftAxisDimensions": []
+                    },
+                    "bandChartSettings": {
+                        "lower": "avg",
+                        "upper": "max",
+                        "time": "timeframe"
+                    },
+                    "truncationMode": "middle"
+                },
+                "singleValue": {
+                    "showLabel": true,
+                    "label": "",
+                    "prefixIcon": "",
+                    "recordField": "net_peer_name",
+                    "autoscale": true,
+                    "alignment": "center",
+                    "colorThresholdTarget": "value"
+                },
+                "table": {
+                    "rowDensity": "condensed",
+                    "enableSparklines": false,
+                    "hiddenColumns": [],
+                    "lineWrapIds": [],
+                    "columnWidths": {}
+                },
+                "honeycomb": {
+                    "shape": "hexagon",
+                    "legend": "auto",
+                    "dataMappings": {
+                        "value": "interval"
+                    },
+                    "displayedFields": [
+                        null
+                    ],
+                    "colorMode": "color-palette",
+                    "colorPalette": "blue"
+                },
+                "histogram": {
+                    "dataMappings": [
+                        {
+                            "valueAxis": "interval",
+                            "rangeAxis": ""
+                        }
+                    ]
+                },
+                "valueBoundaries": {
+                    "min": "auto",
+                    "max": "auto"
+                },
+                "unitsOverrides": [
+                    {
+                        "identifier": "avg(rpc.client.request.size)",
+                        "unitCategory": "data",
+                        "baseUnit": "byte",
+                        "displayUnit": null,
+                        "decimals": 2,
+                        "suffix": "",
+                        "delimiter": false,
+                        "added": 1721215462564
+                    }
+                ]
+            },
+            "querySettings": {
+                "maxResultRecords": 1000,
+                "defaultScanLimitGbytes": 500,
+                "maxResultMegaBytes": 1,
+                "defaultSamplingRatio": 10,
+                "enableSampling": false
+            },
+            "davis": {}
+        },
+        "129": {
+            "title": "Batch size (bytes)",
+            "description": "This tile shows a timeseries of the batch size (in bytes) of the OpenTelemetry Collector.",
+            "type": "data",
+            "query": "// This query retrieves a timeseries of the batch size (in bytes) of the OpenTelemetry Collector.\ntimeseries {max=max(otelcol_processor_batch_batch_send_size_bytes), avg=avg(otelcol_processor_batch_batch_send_size_bytes)}, \n  by: {processor},\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }",
+            "visualization": "lineChart",
+            "visualizationSettings": {
+                "thresholds": [],
+                "chartSettings": {
+                    "xAxisScaling": "analyzedTimeframe",
+                    "gapPolicy": "connect",
+                    "circleChartSettings": {
+                        "groupingThresholdType": "relative",
+                        "groupingThresholdValue": 0,
+                        "valueType": "relative"
+                    },
+                    "categoryOverrides": {},
+                    "hiddenLegendFields": [],
+                    "fieldMapping": {
+                        "timestamp": "timeframe",
+                        "leftAxisValues": [
+                            "max",
+                            "avg"
+                        ],
+                        "leftAxisDimensions": [
+                            "processor"
+                        ]
+                    },
+                    "categoricalBarChartSettings": {
+                        "categoryAxisLabel": "processor",
+                        "valueAxisLabel": "interval",
+                        "categoryAxis": "processor",
+                        "valueAxis": [
+                            "interval"
+                        ],
+                        "tooltipVariant": "single"
+                    },
+                    "truncationMode": "middle",
+                    "bandChartSettings": {
+                        "lower": "avg",
+                        "upper": "max"
+                    },
+                    "xAxisLabel": "timeframe",
+                    "xAxisIsLabelVisible": false,
+                    "valueRepresentation": "absolute",
+                    "leftYAxisSettings": {
+                        "isLabelVisible": true,
+                        "label": "otelcol_processor_batch_batch_send_size_bytes"
+                    }
+                },
+                "singleValue": {
+                    "showLabel": true,
+                    "label": "",
+                    "prefixIcon": "",
+                    "autoscale": true,
+                    "alignment": "center",
+                    "colorThresholdTarget": "value",
+                    "recordField": "service.name"
+                },
+                "table": {
+                    "rowDensity": "condensed",
+                    "enableSparklines": false,
+                    "hiddenColumns": [],
+                    "lineWrapIds": [],
+                    "columnWidths": {},
+                    "columnTypeOverrides": [
+                        {
+                            "fields": [
+                                "max",
+                                "avg"
+                            ],
+                            "value": "sparkline",
+                            "id": 1744115640599
+                        }
+                    ]
+                },
+                "honeycomb": {
+                    "shape": "hexagon",
+                    "legend": "auto",
+                    "dataMappings": {
+                        "value": "interval"
+                    },
+                    "displayedFields": [
+                        "processor"
+                    ],
+                    "colorMode": "color-palette",
+                    "colorPalette": "blue"
+                },
+                "histogram": {
+                    "dataMappings": [
+                        {
+                            "valueAxis": "interval",
+                            "rangeAxis": ""
+                        }
+                    ]
+                },
+                "valueBoundaries": {
+                    "min": "auto",
+                    "max": "auto"
+                }
+            },
+            "querySettings": {
+                "maxResultRecords": 1000,
+                "defaultScanLimitGbytes": 500,
+                "maxResultMegaBytes": 1,
+                "defaultSamplingRatio": 10,
+                "enableSampling": false
+            },
+            "davis": {
+                "enabled": false,
+                "davisVisualization": {
+                    "isAvailable": true
+                }
+            }
+        },
+        "130": {
+            "title": "Batch processor send trigger",
+            "description": "This tile shows a timeseries of the batch processor send triggers of the OpenTelemetry Collector.",
+            "type": "data",
+            "query": "// This query retrieves a timeseries of the batch processor send triggers of the OpenTelemetry Collector.\ntimeseries {`Batch size`=sum(otelcol_processor_batch_batch_size_trigger_send, rollup:count)}, \n  by: {processor},\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }\n| append [\n  timeseries {`Timeout`=sum(otelcol_processor_batch_timeout_trigger_send, rollup:count)}, \n  by: {processor},\n  filter: { in(service.name, $CollectorServiceNames) and k8s.pod.name==$K8sPodName }\n]",
+            "visualization": "lineChart",
+            "visualizationSettings": {
+                "thresholds": [],
+                "chartSettings": {
+                    "xAxisScaling": "analyzedTimeframe",
+                    "gapPolicy": "connect",
+                    "circleChartSettings": {
+                        "groupingThresholdType": "relative",
+                        "groupingThresholdValue": 0,
+                        "valueType": "relative"
+                    },
+                    "categoryOverrides": {},
+                    "hiddenLegendFields": [],
+                    "fieldMapping": {
+                        "timestamp": "timeframe",
+                        "leftAxisValues": [
+                            "Timeout"
+                        ],
+                        "leftAxisDimensions": [
+                            "processor"
+                        ]
+                    },
+                    "categoricalBarChartSettings": {
+                        "categoryAxisLabel": "processor",
+                        "valueAxisLabel": "interval",
+                        "categoryAxis": "processor",
+                        "valueAxis": [
+                            "interval"
+                        ],
+                        "tooltipVariant": "single"
+                    },
+                    "truncationMode": "middle",
+                    "xAxisLabel": "timeframe",
+                    "xAxisIsLabelVisible": false,
+                    "valueRepresentation": "absolute",
+                    "leftYAxisSettings": {}
+                },
+                "singleValue": {
+                    "showLabel": true,
+                    "label": "",
+                    "prefixIcon": "",
+                    "autoscale": true,
+                    "alignment": "center",
+                    "colorThresholdTarget": "value",
+                    "recordField": "service.name"
+                },
+                "table": {
+                    "rowDensity": "condensed",
+                    "enableSparklines": false,
+                    "hiddenColumns": [],
+                    "lineWrapIds": [],
+                    "columnWidths": {},
+                    "columnTypeOverrides": [
+                        {
+                            "fields": [
+                                "Timeout"
+                            ],
+                            "value": "sparkline",
+                            "id": 1744115640828
+                        }
+                    ]
+                },
+                "honeycomb": {
+                    "shape": "hexagon",
+                    "legend": "auto",
+                    "dataMappings": {
+                        "value": "interval"
+                    },
+                    "displayedFields": [
+                        "processor"
+                    ],
+                    "colorMode": "color-palette",
+                    "colorPalette": "blue"
+                },
+                "histogram": {
+                    "dataMappings": [
+                        {
+                            "valueAxis": "interval",
+                            "rangeAxis": ""
+                        }
+                    ]
+                },
+                "valueBoundaries": {
+                    "min": "auto",
+                    "max": "auto"
+                }
+            },
+            "querySettings": {
+                "maxResultRecords": 1000,
+                "defaultScanLimitGbytes": 500,
+                "maxResultMegaBytes": 1,
+                "defaultSamplingRatio": 10,
+                "enableSampling": false
+            },
+            "davis": {
+                "enabled": false,
+                "davisVisualization": {
+                    "isAvailable": true
+                }
+            }
+        },
+        "131": {
+            "type": "markdown",
+            "content": "### Network traffic"
+        },
+        "132": {
+            "type": "markdown",
+            "content": "### OpenTelemetry Collector overview\nThis dashboard is designed to monitor the health and performance of a single OpenTelemetry Collector instance. [Find out how to set up this dashboard](https://docs.dynatrace.com/docs/shortlink/otel-collector-self-monitoring)."
+        },
+        "133": {
+            "type": "markdown",
+            "content": "### Additional resources\n\nLearn more about using the OpenTelemetry Collector with Dynatrace\n* [Dynatrace OpenTelemetry Collector documentation](https://docs.dynatrace.com/docs/ingest-from/opentelemetry/collector)\n* [OpenTelemetry Collector Dynatrace use cases](https://docs.dynatrace.com/docs/ingest-from/opentelemetry/collector/use-cases)\n* [Dynatrace OpenTelemetry Collector Distribution](https://github.com/Dynatrace/dynatrace-otel-collector)"
+        }
+    },
+    "layouts": {
+        "11": {
+            "x": 0,
+            "y": 30,
+            "w": 24,
+            "h": 1
+        },
+        "39": {
+            "x": 0,
+            "y": 15,
+            "w": 8,
+            "h": 3
+        },
+        "42": {
+            "x": 0,
+            "y": 2,
+            "w": 24,
+            "h": 1
+        },
+        "44": {
+            "x": 0,
+            "y": 9,
+            "w": 8,
+            "h": 4
+        },
+        "75": {
+            "x": 0,
+            "y": 3,
+            "w": 8,
+            "h": 6
+        },
+        "76": {
+            "x": 8,
+            "y": 3,
+            "w": 8,
+            "h": 6
+        },
+        "77": {
+            "x": 16,
+            "y": 3,
+            "w": 8,
+            "h": 6
+        },
+        "79": {
+            "x": 8,
+            "y": 9,
+            "w": 8,
+            "h": 4
+        },
+        "80": {
+            "x": 16,
+            "y": 9,
+            "w": 8,
+            "h": 4
+        },
+        "88": {
+            "x": 8,
+            "y": 15,
+            "w": 8,
+            "h": 3
+        },
+        "89": {
+            "x": 16,
+            "y": 15,
+            "w": 8,
+            "h": 3
+        },
+        "90": {
+            "x": 0,
+            "y": 14,
+            "w": 24,
+            "h": 1
+        },
+        "101": {
+            "x": 0,
+            "y": 31,
+            "w": 12,
+            "h": 6
+        },
+        "102": {
+            "x": 12,
+            "y": 31,
+            "w": 12,
+            "h": 6
+        },
+        "105": {
+            "x": 0,
+            "y": 45,
+            "w": 24,
+            "h": 1
+        },
+        "106": {
+            "x": 0,
+            "y": 46,
+            "w": 12,
+            "h": 6
+        },
+        "107": {
+            "x": 12,
+            "y": 46,
+            "w": 12,
+            "h": 6
+        },
+        "108": {
+            "x": 0,
+            "y": 37,
+            "w": 24,
+            "h": 2
+        },
+        "109": {
+            "x": 0,
+            "y": 39,
+            "w": 8,
+            "h": 6
+        },
+        "117": {
+            "x": 0,
+            "y": 18,
+            "w": 24,
+            "h": 1
+        },
+        "118": {
+            "x": 0,
+            "y": 19,
+            "w": 8,
+            "h": 3
+        },
+        "119": {
+            "x": 8,
+            "y": 19,
+            "w": 8,
+            "h": 3
+        },
+        "120": {
+            "x": 16,
+            "y": 19,
+            "w": 8,
+            "h": 3
+        },
+        "121": {
+            "x": 0,
+            "y": 22,
+            "w": 24,
+            "h": 1
+        },
+        "122": {
+            "x": 0,
+            "y": 23,
+            "w": 8,
+            "h": 3
+        },
+        "123": {
+            "x": 8,
+            "y": 23,
+            "w": 8,
+            "h": 3
+        },
+        "124": {
+            "x": 16,
+            "y": 23,
+            "w": 8,
+            "h": 3
+        },
+        "125": {
+            "x": 0,
+            "y": 26,
+            "w": 24,
+            "h": 1
+        },
+        "126": {
+            "x": 0,
+            "y": 27,
+            "w": 8,
+            "h": 3
+        },
+        "127": {
+            "x": 16,
+            "y": 27,
+            "w": 8,
+            "h": 3
+        },
+        "128": {
+            "x": 8,
+            "y": 27,
+            "w": 8,
+            "h": 3
+        },
+        "129": {
+            "x": 8,
+            "y": 39,
+            "w": 8,
+            "h": 6
+        },
+        "130": {
+            "x": 16,
+            "y": 39,
+            "w": 8,
+            "h": 6
+        },
+        "131": {
+            "x": 0,
+            "y": 13,
+            "w": 24,
+            "h": 1
+        },
+        "132": {
+            "x": 0,
+            "y": 0,
+            "w": 24,
+            "h": 2
+        },
+        "133": {
+            "x": 0,
+            "y": 52,
+            "w": 24,
+            "h": 3
+        }
+    },
+    "importedWithCode": false,
+    "settings": {}
+}

--- a/src/scripts/03-install-podmonitor-svcmonitor.sh
+++ b/src/scripts/03-install-podmonitor-svcmonitor.sh
@@ -2,6 +2,8 @@
 
 ## Installs PodMonitor and ServiceMonitor ONLY
 
-echo "*********** Deploying PodMonitor and ServiceMonitor ***********"
-kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.80.1/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
-kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.80.1/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+echo "*********** Deploying PodMonitor, ServiceMonitor, and ScrapeConfigs ***********"
+kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.82.2/example/prometheus-operator-crd/monitoring.coreos.com_servicemonitors.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.82.2/example/prometheus-operator-crd/monitoring.coreos.com_podmonitors.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.82.2/example/prometheus-operator-crd/monitoring.coreos.com_scrapeconfigs.yaml
+kubectl apply --server-side -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.82.2/example/prometheus-operator-crd/monitoring.coreos.com_probes.yaml


### PR DESCRIPTION
* Add internal telemetry for OTel Collector (traces + logs) and capture additional Collector metadata (e.g. Collector k8s pod name and namespace)
* Update readme
* Add updated Single Collector dashboard for Dynatrace